### PR TITLE
Align demo images at bottom

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,16 @@
 
 ### 🎬 Quick Demo
 
-| Protecting Secrets | Blocking Dangerous Commands |
-|:------------------:|:---------------------------:|
-| <img src="assets/block-secrets.png" alt="Hook blocking .env read" width="400"> | <img src="assets/block-dangerous-commands.png" alt="Hook blocking dangerous commands" width="400"> |
+<table>
+  <tr>
+    <th align="center">Protecting Secrets</th>
+    <th align="center">Blocking Dangerous Commands</th>
+  </tr>
+  <tr>
+    <td valign="bottom" align="center"><img src="assets/block-secrets.png" alt="Hook blocking .env read" width="400"></td>
+    <td valign="bottom" align="center"><img src="assets/block-dangerous-commands.png" alt="Hook blocking dangerous commands" width="400"></td>
+  </tr>
+</table>
 
 A growing collection of tested, documented hooks you can copy, paste, and customize.
 


### PR DESCRIPTION
## Summary

- Align demo screenshots at the bottom so the cursor/text level matches across both images
- Use HTML table with `valign="bottom"` for proper vertical alignment