### PR TITLE
feat: add block-no-verify PreToolUse hook to prevent bypassing git hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,12 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          { "type": "command", "command": "npx --yes block-no-verify@1.1.2" }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Closes #4\n\nThis PR adds a `.claude/settings.json` that configures the `block-no-verify` PreToolUse hook, preventing Claude Code from using the skip-hooks flag on git operations.\n\n## What and why\n\nClaude Code can invoke git with a flag that silently skips all pre-commit and pre-push hooks. This bypasses linters, test suites, secret scanners, and other quality gates.\n\nThis repo already does excellent work blocking dangerous shell commands, but the hook-bypass flag was missing from coverage. Adding `block-no-verify@1.1.2` fills that gap using the same PreToolUse Bash matcher pattern already established here.\n\n## Changes\n\n- Added `.claude/settings.json` with a PreToolUse Bash hook running `npx --yes block-no-verify@1.1.2`\n\n## Testing\n\nThe `block-no-verify` package handles detection and blocking. No additional tests needed in this repo.\n\n_Disclosure: I am the author and maintainer of `block-no-verify`._