### PR TITLE
Respect CLAUDE_CONFIG_DIR for hooks-logs path

### DIFF
--- a/hook-scripts/notification/notify-permission.js
+++ b/hook-scripts/notification/notify-permission.js
@@ -22,7 +22,7 @@ const path = require('path');
 // Channel webhooks (Discord/Telegram coming soon)
 const SLACK_WEBHOOK = process.env.CCH_SLA_WEBHOOK || '';
 
-const LOG_DIR = path.join(process.env.HOME, '.claude', 'hooks-logs');
+const LOG_DIR = path.join(process.env.CLAUDE_CONFIG_DIR || path.join(process.env.HOME, '.claude'), 'hooks-logs');
 
 function log(data) {
   try {

--- a/hook-scripts/post-tool-use/auto-stage.js
+++ b/hook-scripts/post-tool-use/auto-stage.js
@@ -26,7 +26,7 @@ const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');
 
-const LOG_DIR = path.join(process.env.HOME, '.claude', 'hooks-logs');
+const LOG_DIR = path.join(process.env.CLAUDE_CONFIG_DIR || path.join(process.env.HOME, '.claude'), 'hooks-logs');
 
 function log(data) {
   try {

--- a/hook-scripts/pre-tool-use/block-dangerous-commands.js
+++ b/hook-scripts/pre-tool-use/block-dangerous-commands.js
@@ -59,7 +59,7 @@ const PATTERNS = [
 
 const LEVELS = { critical: 1, high: 2, strict: 3 };
 const EMOJIS = { critical: '🚨', high: '⛔', strict: '⚠️' };
-const LOG_DIR = path.join(process.env.HOME, '.claude', 'hooks-logs');
+const LOG_DIR = path.join(process.env.CLAUDE_CONFIG_DIR || path.join(process.env.HOME, '.claude'), 'hooks-logs');
 
 function log(data) {
   try {

--- a/hook-scripts/pre-tool-use/protect-secrets.js
+++ b/hook-scripts/pre-tool-use/protect-secrets.js
@@ -115,7 +115,7 @@ const BASH_PATTERNS = [
 
 const LEVELS = { critical: 1, high: 2, strict: 3 };
 const EMOJIS = { critical: '🔐', high: '🛡️', strict: '⚠️' };
-const LOG_DIR = path.join(process.env.HOME, '.claude', 'hooks-logs');
+const LOG_DIR = path.join(process.env.CLAUDE_CONFIG_DIR || path.join(process.env.HOME, '.claude'), 'hooks-logs');
 
 function log(data) {
   try {

--- a/hook-scripts/utils/event-logger.py
+++ b/hook-scripts/utils/event-logger.py
@@ -36,7 +36,7 @@ from pathlib import Path
 
 
 def get_log_file_path():
-    log_dir = Path.home() / ".claude" / "hooks-logs"
+    log_dir = Path(os.environ.get("CLAUDE_CONFIG_DIR", Path.home() / ".claude")) / "hooks-logs"
     log_dir.mkdir(parents=True, exist_ok=True)
     return log_dir / f"{datetime.now().strftime('%Y-%m-%d')}.jsonl"
 


### PR DESCRIPTION
## Summary
- Use `CLAUDE_CONFIG_DIR` env var (when set) to determine where `hooks-logs/` is written
- Falls back to `~/.claude` if the env var is unset, preserving existing behavior

This is useful for users who customize their Claude Code config directory via `CLAUDE_CONFIG_DIR` (e.g. for XDG Base Directory compliance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)