### PR TITLE
fix: prevent command injection in auto-stage.js

### DIFF
--- a/hook-scripts/post-tool-use/auto-stage.js
+++ b/hook-scripts/post-tool-use/auto-stage.js
@@ -24,7 +24,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { execSync } = require('child_process');
+const { execSync, spawnSync } = require('child_process');
 
 const LOG_DIR = path.join(process.env.HOME, '.claude', 'hooks-logs');
 
@@ -49,7 +49,11 @@ function isInGitRepo(filePath) {
 function stageFile(filePath) {
   try {
     const dir = path.dirname(filePath);
-    execSync(`git add "${filePath}"`, { cwd: dir, stdio: 'pipe' });
+    const result = spawnSync('git', ['add', '--', filePath], { cwd: dir, stdio: 'pipe' });
+    if (result.status !== 0) {
+      const stderr = result.stderr ? result.stderr.toString() : '';
+      return { success: false, error: stderr || `exit code ${result.status}` };
+    }
     return { success: true };
   } catch (e) {
     return { success: false, error: e.message };

--- a/hook-scripts/tests/post-tool-use/auto-stage.test.js
+++ b/hook-scripts/tests/post-tool-use/auto-stage.test.js
@@ -95,6 +95,28 @@ describe('Unit: stageFile()', () => {
     const result = stageFile(path.join(tempDir, 'nonexistent.txt'));
     assert.ok('success' in result);
   });
+
+  it('does not execute shell commands embedded in filenames', () => {
+    // A filename containing shell metacharacters must be treated as a literal
+    // path, not executed. With the old execSync(`git add "${filePath}"`), a
+    // name like: evil"; touch marker; echo "x  would break out of the quotes
+    // and run `touch marker` with cwd=tempDir.
+    const markerName = `injection-marker-${Date.now()}`;
+    const markerPath = path.join(tempDir, markerName);
+    // Use only characters valid in a Unix filename (no slashes).
+    // The injected command touches markerName relative to cwd (tempDir).
+    const maliciousName = `evil"; touch ${markerName}; echo "x.txt`;
+    const maliciousFile = path.join(tempDir, maliciousName);
+    fs.writeFileSync(maliciousFile, 'payload');
+
+    stageFile(maliciousFile);
+
+    assert.strictEqual(
+      fs.existsSync(markerPath),
+      false,
+      `Shell injection succeeded — marker file was created at ${markerPath}`
+    );
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Vulnerability:** `stageFile()` in `auto-stage.js` built a shell command using template string interpolation — `execSync(\`git add "${filePath}"\`)`. A filename containing `"` followed by shell metacharacters (e.g. `evil"; touch marker; echo "x.txt`) breaks out of the quotes and executes arbitrary commands when the PostToolUse hook fires.
- **Fix:** Replace `execSync` with `spawnSync('git', ['add', '--', filePath], ...)`, which passes the filename as a literal argument without involving a shell. The `--` prevents git from interpreting filenames that begin with `-` as flags.
- **Regression test added:** Creates a file whose name embeds a `touch` command and asserts the marker file is not created after `stageFile` runs.

## Security context

This was identified during a code audit. The attack requires either:
1. Claude being induced to write a file with a crafted name, or
2. A repo that already contains a file with shell metacharacters in its name

Both are realistic in adversarial or misconfigured environments. The fix has zero functional impact on normal usage.

## Test plan

- [x] All 263 existing tests still pass (`npm test`)
- [x] New regression test passes (confirms injection is blocked)
- [x] Verified fix works: with the old `execSync` the new test fails (marker file is created); with `spawnSync` it passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)