### PR TITLE
feat: add per-level ask mode for hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![GitHub stars](https://img.shields.io/github/stars/karanb192/claude-code-hooks?style=social)](https://github.com/karanb192/claude-code-hooks)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Tests](https://img.shields.io/badge/tests-1149%20passing-brightgreen)](https://github.com/karanb192/claude-code-hooks/actions)
+[![Tests](https://img.shields.io/badge/tests-1165%20passing-brightgreen)](https://github.com/karanb192/claude-code-hooks/actions)
 
 **🌐 [Live site & catalog](https://karanb192.github.io/claude-code-hooks/)**
 
@@ -192,6 +192,29 @@ Security hooks support configurable safety levels:
 ```javascript
 const SAFETY_LEVEL = "strict"; // or 'critical', 'high'
 ```
+
+### 🙋 Ask mode (prompt instead of block)
+
+`block-dangerous-commands` and `protect-secrets` can **ask** instead of denying outright. When ask mode is on for a level, matching operations return `permissionDecision: "ask"` — Claude Code shows the reason and lets you approve or reject, instead of hard-blocking.
+
+Enable per level via environment variables (the literal string `true`; anything else means deny):
+
+| Variable            | Affects                                        |
+| ------------------- | ---------------------------------------------- |
+| `HOOK_ASK_CRITICAL` | `critical`-level patterns (rm -rf ~, .env, …)  |
+| `HOOK_ASK_HIGH`     | `high`-level patterns (git reset --hard, …)    |
+| `HOOK_ASK_STRICT`   | `strict`-level patterns (any force push, …)    |
+
+Set them inline in your hook command in `settings.json`:
+
+```json
+{
+  "type": "command",
+  "command": "HOOK_ASK_STRICT=true node ~/.claude/hooks/block-dangerous-commands.js"
+}
+```
+
+Everything defaults to **deny** — ask mode is strictly opt-in. A common setup: keep `critical` on deny, set `HOOK_ASK_STRICT=true` so cautionary patterns prompt instead of blocking.
 
 ---
 

--- a/hook-scripts/pre-tool-use/block-dangerous-commands.js
+++ b/hook-scripts/pre-tool-use/block-dangerous-commands.js
@@ -24,6 +24,17 @@ const path = require('path');
 
 const SAFETY_LEVEL = 'high';
 
+// Ask mode per level: if true, prompts the user instead of blocking outright.
+// When ask=true, the hook returns decision "ask" so Claude Code shows the
+// reason and lets the user decide. When ask=false (default), the hook denies.
+// Env overrides: HOOK_ASK_CRITICAL, HOOK_ASK_HIGH, HOOK_ASK_STRICT
+const envBool = (key, fallback) => key in process.env ? process.env[key] === 'true' : fallback;
+const ASK = {
+  critical: envBool('HOOK_ASK_CRITICAL', false),
+  high:     envBool('HOOK_ASK_HIGH', false),
+  strict:   envBool('HOOK_ASK_STRICT', false),
+};
+
 const PATTERNS = [
   // CRITICAL - Catastrophic, unrecoverable
   { level: 'critical', id: 'rm-home',          regex: /\brm\s+(-.+\s+)*["']?~\/?["']?(\s|$|[;&|])/,                        reason: 'rm targeting home directory' },
@@ -42,12 +53,7 @@ const PATTERNS = [
   { level: 'high', id: 'git-reset-hard', regex: /\bgit\s+reset\s+--hard/,                                                 reason: 'git reset --hard loses uncommitted work' },
   { level: 'high', id: 'git-clean-f',    regex: /\bgit\s+clean\s+(-\w*f|-f)/,                                             reason: 'git clean -f deletes untracked files' },
   { level: 'high', id: 'chmod-777',      regex: /\bchmod\b.+\b777\b/,                                                     reason: 'chmod 777 is a security risk' },
-  { level: 'high', id: 'cat-env',        regex: /\b(cat|less|head|tail|more)\s+\.env\b/,                                  reason: 'reading .env file exposes secrets' },
-  { level: 'high', id: 'cat-secrets',    regex: /\b(cat|less|head|tail|more)\b.+(credentials|secrets?|\.pem|\.key|id_rsa|id_ed25519)/i, reason: 'reading secrets file' },
-  { level: 'high', id: 'env-dump',       regex: /\b(printenv|^env)\s*([;&|]|$)/,                                          reason: 'env dump may expose secrets' },
-  { level: 'high', id: 'echo-secret',    regex: /\becho\b.+\$\w*(SECRET|KEY|TOKEN|PASSWORD|API_|PRIVATE)/i,               reason: 'echoing secret variable' },
   { level: 'high', id: 'docker-vol-rm',  regex: /\bdocker\s+volume\s+(rm|prune)/,                                         reason: 'docker volume deletion loses data' },
-  { level: 'high', id: 'rm-ssh',         regex: /\brm\b.+\.ssh\/(id_|authorized_keys|known_hosts)/,                       reason: 'deleting SSH keys' },
 
   // STRICT - Cautionary, context-dependent
   { level: 'strict', id: 'git-force-any',    regex: /\bgit\s+push\b(?!.+--force-with-lease).+(--force|-f)\b/,              reason: 'force push (use --force-with-lease)' },
@@ -93,11 +99,13 @@ async function main() {
 
     if (result.blocked) {
       const p = result.pattern;
-      log({ level: 'BLOCKED', id: p.id, priority: p.level, cmd, session_id, cwd, permission_mode });
+      const shouldAsk = ASK[p.level] === true;
+      const decision = shouldAsk ? 'ask' : 'deny';
+      log({ level: shouldAsk ? 'ASK' : 'BLOCKED', id: p.id, priority: p.level, decision, cmd, session_id, cwd, permission_mode });
       return console.log(JSON.stringify({
         hookSpecificOutput: {
           hookEventName: 'PreToolUse',
-          permissionDecision: 'deny',
+          permissionDecision: decision,
           permissionDecisionReason: `${EMOJIS[p.level]} [${p.id}] ${p.reason}`
         }
       }));
@@ -112,5 +120,5 @@ async function main() {
 if (require.main === module) {
   main();
 } else {
-  module.exports = { PATTERNS, LEVELS, SAFETY_LEVEL, checkCommand };
+  module.exports = { PATTERNS, LEVELS, SAFETY_LEVEL, ASK, checkCommand };
 }

--- a/hook-scripts/pre-tool-use/block-dangerous-commands.js
+++ b/hook-scripts/pre-tool-use/block-dangerous-commands.js
@@ -8,6 +8,11 @@
  *   high     - + risky: force push main, secrets exposure, git reset --hard
  *   strict   - + cautionary: any force push, sudo rm, docker prune
  *
+ * Ask mode (opt-in, per level): set HOOK_ASK_CRITICAL / HOOK_ASK_HIGH /
+ * HOOK_ASK_STRICT to the literal string "true" in the hook command to have
+ * that level prompt the user ("ask") instead of blocking outright ("deny").
+ * e.g. "command": "HOOK_ASK_STRICT=true node /path/to/block-dangerous-commands.js"
+ *
  * Setup in .claude/settings.json:
  * {
  *   "hooks": {

--- a/hook-scripts/pre-tool-use/protect-secrets.js
+++ b/hook-scripts/pre-tool-use/protect-secrets.js
@@ -25,6 +25,17 @@ const path = require('path');
 
 const SAFETY_LEVEL = 'high';
 
+// Ask mode per level: if true, prompts the user instead of blocking outright.
+// When ask=true, the hook returns decision "ask" so Claude Code shows the
+// reason and lets the user decide. When ask=false (default), the hook denies.
+// Env overrides: HOOK_ASK_CRITICAL, HOOK_ASK_HIGH, HOOK_ASK_STRICT
+const envBool = (key, fallback) => key in process.env ? process.env[key] === 'true' : fallback;
+const ASK = {
+  critical: envBool('HOOK_ASK_CRITICAL', false),
+  high:     envBool('HOOK_ASK_HIGH', false),
+  strict:   envBool('HOOK_ASK_STRICT', false),
+};
+
 // Files explicitly safe to access (templates, examples)
 const ALLOWLIST = [
   /\.env\.example$/i, /\.env\.sample$/i, /\.env\.template$/i,
@@ -180,14 +191,16 @@ async function main() {
 
     if (result.blocked) {
       const p = result.pattern;
+      const shouldAsk = ASK[p.level] === true;
+      const decision = shouldAsk ? 'ask' : 'deny';
       const target = tool_input?.file_path || tool_input?.command?.slice(0, 100);
-      log({ level: 'BLOCKED', id: p.id, priority: p.level, tool: tool_name, target, session_id, cwd, permission_mode });
+      log({ level: shouldAsk ? 'ASK' : 'BLOCKED', id: p.id, priority: p.level, decision, tool: tool_name, target, session_id, cwd, permission_mode });
 
       const action = { Read: 'read', Edit: 'modify', Write: 'write to', Bash: 'execute' }[tool_name];
       return console.log(JSON.stringify({
         hookSpecificOutput: {
           hookEventName: 'PreToolUse',
-          permissionDecision: 'deny',
+          permissionDecision: decision,
           permissionDecisionReason: `${EMOJIS[p.level]} [${p.id}] Cannot ${action}: ${p.reason}`
         }
       }));
@@ -203,7 +216,7 @@ if (require.main === module) {
   main();
 } else {
   module.exports = {
-    SENSITIVE_FILES, BASH_PATTERNS, ALLOWLIST, LEVELS, SAFETY_LEVEL,
+    SENSITIVE_FILES, BASH_PATTERNS, ALLOWLIST, LEVELS, SAFETY_LEVEL, ASK,
     check, checkFilePath, checkBashCommand, isAllowlisted,
   };
 }

--- a/hook-scripts/pre-tool-use/protect-secrets.js
+++ b/hook-scripts/pre-tool-use/protect-secrets.js
@@ -9,6 +9,11 @@
  *   high     - + secrets files, env dumps, exfiltration attempts
  *   strict   - + database configs, any config that might contain secrets
  *
+ * Ask mode (opt-in, per level): set HOOK_ASK_CRITICAL / HOOK_ASK_HIGH /
+ * HOOK_ASK_STRICT to the literal string "true" in the hook command to have
+ * that level prompt the user ("ask") instead of blocking outright ("deny").
+ * e.g. "command": "HOOK_ASK_STRICT=true node /path/to/protect-secrets.js"
+ *
  * Setup in .claude/settings.json:
  * {
  *   "hooks": {

--- a/hook-scripts/tests/pre-tool-use/block-dangerous-commands.test.js
+++ b/hook-scripts/tests/pre-tool-use/block-dangerous-commands.test.js
@@ -12,7 +12,7 @@ const { spawn } = require('node:child_process');
 const path = require('node:path');
 
 // Import from the actual script
-const { PATTERNS, LEVELS, SAFETY_LEVEL, checkCommand } = require('../../pre-tool-use/block-dangerous-commands.js');
+const { PATTERNS, LEVELS, SAFETY_LEVEL, ASK, checkCommand } = require('../../pre-tool-use/block-dangerous-commands.js');
 
 const SCRIPT_PATH = path.join(__dirname, '../../pre-tool-use/block-dangerous-commands.js');
 
@@ -120,22 +120,20 @@ describe('Unit: checkCommand()', () => {
     it('allows git push', () => shouldAllow('git push origin main'));
   });
 
-  describe('HIGH: secrets exposure', () => {
-    it('blocks cat .env', () => shouldBlock('cat .env', 'cat-env'));
-    it('blocks cat credentials.json', () => shouldBlock('cat credentials.json', 'cat-secrets'));
-    it('blocks printenv', () => shouldBlock('printenv', 'env-dump'));
-    it('blocks echo $SECRET_KEY', () => shouldBlock('echo $SECRET_KEY', 'echo-secret'));
-    it('allows cat package.json', () => shouldAllow('cat package.json'));
-  });
-
   describe('HIGH: chmod 777', () => {
     it('blocks chmod 777', () => shouldBlock('chmod 777 file.sh', 'chmod-777'));
     it('allows chmod 755', () => shouldAllow('chmod 755 script.sh'));
   });
 
-  describe('HIGH: docker & SSH', () => {
+  describe('HIGH: docker', () => {
     it('blocks docker volume rm', () => shouldBlock('docker volume rm vol', 'docker-vol-rm'));
-    it('blocks rm id_rsa', () => shouldBlock('rm ~/.ssh/id_rsa', 'rm-ssh'));
+  });
+
+  describe('Secrets handled by protect-secrets (not this script)', () => {
+    it('allows cat .env (delegated to protect-secrets)', () => shouldAllow('cat .env'));
+    it('allows printenv (delegated to protect-secrets)', () => shouldAllow('printenv'));
+    it('allows echo $SECRET_KEY (delegated to protect-secrets)', () => shouldAllow('echo $SECRET_KEY'));
+    it('allows rm ~/.ssh/id_rsa (delegated to protect-secrets)', () => shouldAllow('rm ~/.ssh/id_rsa'));
   });
 
   describe('STRICT: other patterns (requires strict level)', () => {
@@ -245,5 +243,40 @@ describe('Config: PATTERNS structure', () => {
     assert.strictEqual(LEVELS.critical, 1);
     assert.strictEqual(LEVELS.high, 2);
     assert.strictEqual(LEVELS.strict, 3);
+  });
+
+  it('ASK has valid boolean values for each level', () => {
+    for (const level of ['critical', 'high', 'strict']) {
+      assert.ok(level in ASK, `ASK missing level: ${level}`);
+      assert.strictEqual(typeof ASK[level], 'boolean', `ASK.${level} is not boolean`);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Integration Tests - ask mode
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Integration: ask mode', () => {
+  it('returns "ask" decision for strict-level pattern when ASK.strict is true', async () => {
+    // strict patterns are only active at strict safety level
+    // ASK.strict defaults to true, so matching patterns should return "ask"
+    if (!ASK.strict) return; // skip if default changed
+
+    // We need a custom runner that sets SAFETY_LEVEL to strict
+    // Instead, test via the integration output — strict patterns require strict level
+    // so we test the default ASK config expectation
+    assert.strictEqual(ASK.strict, false, 'Default ASK.strict should be false');
+    assert.strictEqual(ASK.critical, false, 'Default ASK.critical should be false');
+  });
+
+  it('returns "deny" decision for critical-level pattern (ASK.critical=false)', async () => {
+    const { output } = await runHook('rm -rf ~/');
+    assert.strictEqual(output.hookSpecificOutput?.permissionDecision, 'deny');
+  });
+
+  it('returns "deny" decision for high-level pattern (ASK.high=false)', async () => {
+    const { output } = await runHook('git reset --hard HEAD~1');
+    assert.strictEqual(output.hookSpecificOutput?.permissionDecision, 'deny');
   });
 });

--- a/hook-scripts/tests/pre-tool-use/block-dangerous-commands.test.js
+++ b/hook-scripts/tests/pre-tool-use/block-dangerous-commands.test.js
@@ -33,10 +33,16 @@ function shouldAllow(cmd, safetyLevel = undefined) {
   assert.strictEqual(result.blocked, false, `Expected ALLOWED but was BLOCKED by '${result.pattern?.id}': ${cmd}`);
 }
 
-// Spawns the actual script and returns parsed output
-function runHook(command) {
+// Spawns the actual script and returns parsed output.
+// Hermetic by default: HOOK_ASK_* is never inherited from the runner's shell —
+// tests opt in explicitly via envOverrides.
+function runHook(command, envOverrides = {}) {
   return new Promise((resolve, reject) => {
-    const child = spawn('node', [SCRIPT_PATH]);
+    const env = { ...process.env, ...envOverrides };
+    for (const key of Object.keys(env)) {
+      if (key.startsWith('HOOK_ASK_') && !(key in envOverrides)) delete env[key];
+    }
+    const child = spawn('node', [SCRIPT_PATH], { env });
     let stdout = '';
     let stderr = '';
 
@@ -258,24 +264,42 @@ describe('Config: PATTERNS structure', () => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe('Integration: ask mode', () => {
-  it('returns "ask" decision for strict-level pattern when ASK.strict is true', async () => {
-    // strict patterns are only active at strict safety level
-    // ASK.strict defaults to true, so matching patterns should return "ask"
-    if (!ASK.strict) return; // skip if default changed
-
-    // We need a custom runner that sets SAFETY_LEVEL to strict
-    // Instead, test via the integration output — strict patterns require strict level
-    // so we test the default ASK config expectation
-    assert.strictEqual(ASK.strict, false, 'Default ASK.strict should be false');
-    assert.strictEqual(ASK.critical, false, 'Default ASK.critical should be false');
+  it('returns "ask" for a critical-level pattern when HOOK_ASK_CRITICAL=true', async () => {
+    const { output } = await runHook('rm -rf ~/', { HOOK_ASK_CRITICAL: 'true' });
+    assert.strictEqual(output.hookSpecificOutput?.permissionDecision, 'ask');
   });
 
-  it('returns "deny" decision for critical-level pattern (ASK.critical=false)', async () => {
+  it('returns "ask" for a high-level pattern when HOOK_ASK_HIGH=true', async () => {
+    const { output } = await runHook('git reset --hard HEAD~1', { HOOK_ASK_HIGH: 'true' });
+    assert.strictEqual(output.hookSpecificOutput?.permissionDecision, 'ask');
+  });
+
+  it('keeps the pattern id and reason in the ask prompt', async () => {
+    const { output } = await runHook('git reset --hard HEAD~1', { HOOK_ASK_HIGH: 'true' });
+    assert.match(output.hookSpecificOutput?.permissionDecisionReason ?? '', /\[git-reset-hard\]/);
+  });
+
+  it('ask mode is per level: HOOK_ASK_HIGH=true does not soften a critical pattern', async () => {
+    const { output } = await runHook('rm -rf ~/', { HOOK_ASK_HIGH: 'true' });
+    assert.strictEqual(output.hookSpecificOutput?.permissionDecision, 'deny');
+  });
+
+  it('only the literal string "true" enables ask mode ("1" does not)', async () => {
+    const { output } = await runHook('git reset --hard HEAD~1', { HOOK_ASK_HIGH: '1' });
+    assert.strictEqual(output.hookSpecificOutput?.permissionDecision, 'deny');
+  });
+
+  it('explicit "false" keeps deny', async () => {
+    const { output } = await runHook('git reset --hard HEAD~1', { HOOK_ASK_HIGH: 'false' });
+    assert.strictEqual(output.hookSpecificOutput?.permissionDecision, 'deny');
+  });
+
+  it('defaults to "deny" for a critical-level pattern when no HOOK_ASK_* is set', async () => {
     const { output } = await runHook('rm -rf ~/');
     assert.strictEqual(output.hookSpecificOutput?.permissionDecision, 'deny');
   });
 
-  it('returns "deny" decision for high-level pattern (ASK.high=false)', async () => {
+  it('defaults to "deny" for a high-level pattern when no HOOK_ASK_* is set', async () => {
     const { output } = await runHook('git reset --hard HEAD~1');
     assert.strictEqual(output.hookSpecificOutput?.permissionDecision, 'deny');
   });

--- a/hook-scripts/tests/pre-tool-use/protect-secrets.test.js
+++ b/hook-scripts/tests/pre-tool-use/protect-secrets.test.js
@@ -17,6 +17,7 @@ const {
   ALLOWLIST,
   LEVELS,
   SAFETY_LEVEL,
+  ASK,
   check,
   checkFilePath,
   checkBashCommand,
@@ -439,5 +440,34 @@ describe('Config: Pattern structures', () => {
     assert.strictEqual(LEVELS.critical, 1);
     assert.strictEqual(LEVELS.high, 2);
     assert.strictEqual(LEVELS.strict, 3);
+  });
+
+  it('ASK has valid boolean values for each level', () => {
+    for (const level of ['critical', 'high', 'strict']) {
+      assert.ok(level in ASK, `ASK missing level: ${level}`);
+      assert.strictEqual(typeof ASK[level], 'boolean', `ASK.${level} is not boolean`);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Integration Tests - ask mode
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Integration: ask mode', () => {
+  it('returns "deny" for critical-level file (ASK.critical=false)', async () => {
+    const { output } = await runHook('Read', { file_path: '/app/.env' });
+    assert.strictEqual(output.hookSpecificOutput?.permissionDecision, 'deny');
+  });
+
+  it('returns "deny" for high-level bash pattern (ASK.high=false)', async () => {
+    const { output } = await runHook('Bash', { command: 'echo $SECRET_KEY' });
+    assert.strictEqual(output.hookSpecificOutput?.permissionDecision, 'deny');
+  });
+
+  it('ASK defaults are correct', () => {
+    assert.strictEqual(ASK.critical, false, 'Default ASK.critical should be false');
+    assert.strictEqual(ASK.high, false, 'Default ASK.high should be false');
+    assert.strictEqual(ASK.strict, false, 'Default ASK.strict should be false');
   });
 });

--- a/hook-scripts/tests/pre-tool-use/protect-secrets.test.js
+++ b/hook-scripts/tests/pre-tool-use/protect-secrets.test.js
@@ -56,9 +56,15 @@ function bashAllowed(cmd, level = undefined) {
   assert.strictEqual(result.blocked, false, `Expected ALLOWED but BLOCKED by '${result.pattern?.id}': ${cmd}`);
 }
 
-function runHook(toolName, toolInput) {
+// Hermetic by default: HOOK_ASK_* is never inherited from the runner's shell —
+// tests opt in explicitly via envOverrides.
+function runHook(toolName, toolInput, envOverrides = {}) {
   return new Promise((resolve, reject) => {
-    const child = spawn('node', [SCRIPT_PATH]);
+    const env = { ...process.env, ...envOverrides };
+    for (const key of Object.keys(env)) {
+      if (key.startsWith('HOOK_ASK_') && !(key in envOverrides)) delete env[key];
+    }
+    const child = spawn('node', [SCRIPT_PATH], { env });
     let stdout = '';
     let stderr = '';
 
@@ -455,19 +461,43 @@ describe('Config: Pattern structures', () => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe('Integration: ask mode', () => {
-  it('returns "deny" for critical-level file (ASK.critical=false)', async () => {
+  it('returns "ask" for a critical-level file when HOOK_ASK_CRITICAL=true', async () => {
+    const { output } = await runHook('Read', { file_path: '/app/.env' }, { HOOK_ASK_CRITICAL: 'true' });
+    assert.strictEqual(output.hookSpecificOutput?.permissionDecision, 'ask');
+  });
+
+  it('returns "ask" for a high-level bash pattern when HOOK_ASK_HIGH=true', async () => {
+    const { output } = await runHook('Bash', { command: 'echo $SECRET_KEY' }, { HOOK_ASK_HIGH: 'true' });
+    assert.strictEqual(output.hookSpecificOutput?.permissionDecision, 'ask');
+  });
+
+  it('keeps the pattern id and tool action in the ask prompt', async () => {
+    const { output } = await runHook('Read', { file_path: '/app/.env' }, { HOOK_ASK_CRITICAL: 'true' });
+    assert.match(output.hookSpecificOutput?.permissionDecisionReason ?? '', /\[env-file\] Cannot read/);
+  });
+
+  it('ask mode is per level: HOOK_ASK_HIGH=true does not soften a critical file', async () => {
+    const { output } = await runHook('Read', { file_path: '/app/.env' }, { HOOK_ASK_HIGH: 'true' });
+    assert.strictEqual(output.hookSpecificOutput?.permissionDecision, 'deny');
+  });
+
+  it('only the literal string "true" enables ask mode ("TRUE" does not)', async () => {
+    const { output } = await runHook('Bash', { command: 'echo $SECRET_KEY' }, { HOOK_ASK_HIGH: 'TRUE' });
+    assert.strictEqual(output.hookSpecificOutput?.permissionDecision, 'deny');
+  });
+
+  it('explicit "false" keeps deny', async () => {
+    const { output } = await runHook('Bash', { command: 'echo $SECRET_KEY' }, { HOOK_ASK_HIGH: 'false' });
+    assert.strictEqual(output.hookSpecificOutput?.permissionDecision, 'deny');
+  });
+
+  it('defaults to "deny" for a critical-level file when no HOOK_ASK_* is set', async () => {
     const { output } = await runHook('Read', { file_path: '/app/.env' });
     assert.strictEqual(output.hookSpecificOutput?.permissionDecision, 'deny');
   });
 
-  it('returns "deny" for high-level bash pattern (ASK.high=false)', async () => {
+  it('defaults to "deny" for a high-level bash pattern when no HOOK_ASK_* is set', async () => {
     const { output } = await runHook('Bash', { command: 'echo $SECRET_KEY' });
     assert.strictEqual(output.hookSpecificOutput?.permissionDecision, 'deny');
-  });
-
-  it('ASK defaults are correct', () => {
-    assert.strictEqual(ASK.critical, false, 'Default ASK.critical should be false');
-    assert.strictEqual(ASK.high, false, 'Default ASK.high should be false');
-    assert.strictEqual(ASK.strict, false, 'Default ASK.strict should be false');
   });
 });


### PR DESCRIPTION
## Summary
- Add configurable `ASK` mode per security level (`critical`, `high`, `strict`) to both `block-dangerous-commands.js` and `protect-secrets.js`
- When `ask=true` for a level, the hook returns `permissionDecision: "ask"` instead of `"deny"`, letting Claude Code prompt the user with context instead of blocking outright
- Defaults to `false` (deny) for all levels; users can override via env vars (`HOOK_ASK_CRITICAL`, `HOOK_ASK_HIGH`, `HOOK_ASK_STRICT`) in their `settings.json` command
- Remove 5 duplicate secrets-related patterns from `block-dangerous-commands.js` (`cat-env`, `cat-secrets`, `env-dump`, `echo-secret`, `rm-ssh`) to avoid conflicts with `protect-secrets.js` which is the single owner for all secrets patterns

## Test plan
- [x] All 268 tests pass (`npm test`)
- [x] Verified `ASK` defaults are all `false`
- [x] Verified env var override works (e.g. `HOOK_ASK_HIGH=true node script.js`)
- [x] Verified no pattern conflicts between the two scripts
- [x] Integration tests confirm `deny` for critical/high and correct decision routing

🤖 Generated with [Claude Code](https://claude.com/claude-code)