### PR TITLE
feat(hooks): add format-code PostToolUse hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ Runs **before** Claude executes a tool. Can block or modify the operation.
 
 Runs **after** Claude executes a tool. Can react to results.
 
-| Hook                                                     | Matcher       | Description                                                              |
-| -------------------------------------------------------- | ------------- | ------------------------------------------------------------------------ |
-| [auto-stage](hook-scripts/post-tool-use/auto-stage.js)   | `Edit\|Write` | Automatically git stages files after Claude modifies them                |
-| [format-code](hook-scripts/post-tool-use/format-code.js) | `Write\|Edit` | Auto-formats Python (ruff) and Markdown/YAML/JSON (prettier) after edits |
+| Hook                                                     | Matcher       | Description                                                                   |
+| -------------------------------------------------------- | ------------- | ----------------------------------------------------------------------------- |
+| [auto-stage](hook-scripts/post-tool-use/auto-stage.js)   | `Edit\|Write` | Automatically git stages files after Claude modifies them                     |
+| [format-code](hook-scripts/post-tool-use/format-code.js) | `Write\|Edit` | Auto-formats Python (ruff) and JS/TS/HTML/JSON/MD/YAML (prettier) after edits |
 
 ### Notification
 

--- a/README.md
+++ b/README.md
@@ -39,34 +39,35 @@ A growing collection of tested, documented hooks you can copy, paste, and custom
 
 Runs **before** Claude executes a tool. Can block or modify the operation.
 
-| Hook | Matcher | Description |
-|------|---------|-------------|
-| [block-dangerous-commands](hook-scripts/pre-tool-use/block-dangerous-commands.js) | `Bash` | Blocks dangerous shell commands (rm -rf ~, fork bombs, curl\|sh) |
-| [protect-secrets](hook-scripts/pre-tool-use/protect-secrets.js) | `Read\|Edit\|Write\|Bash` | Prevents reading/modifying/exfiltrating sensitive files |
+| Hook                                                                              | Matcher                   | Description                                                      |
+| --------------------------------------------------------------------------------- | ------------------------- | ---------------------------------------------------------------- |
+| [block-dangerous-commands](hook-scripts/pre-tool-use/block-dangerous-commands.js) | `Bash`                    | Blocks dangerous shell commands (rm -rf ~, fork bombs, curl\|sh) |
+| [protect-secrets](hook-scripts/pre-tool-use/protect-secrets.js)                   | `Read\|Edit\|Write\|Bash` | Prevents reading/modifying/exfiltrating sensitive files          |
 
 ### Post-Tool-Use
 
 Runs **after** Claude executes a tool. Can react to results.
 
-| Hook | Matcher | Description |
-|------|---------|-------------|
-| [auto-stage](hook-scripts/post-tool-use/auto-stage.js) | `Edit\|Write` | Automatically git stages files after Claude modifies them |
+| Hook                                                     | Matcher       | Description                                                              |
+| -------------------------------------------------------- | ------------- | ------------------------------------------------------------------------ |
+| [auto-stage](hook-scripts/post-tool-use/auto-stage.js)   | `Edit\|Write` | Automatically git stages files after Claude modifies them                |
+| [format-code](hook-scripts/post-tool-use/format-code.js) | `Write\|Edit` | Auto-formats Python (ruff) and Markdown/YAML/JSON (prettier) after edits |
 
 ### Notification
 
 Fires when Claude needs user attention.
 
-| Hook | Matcher | Description |
-|------|---------|-------------|
+| Hook                                                                | Matcher                          | Description                                |
+| ------------------------------------------------------------------- | -------------------------------- | ------------------------------------------ |
 | [notify-permission](hook-scripts/notification/notify-permission.js) | `permission_prompt\|idle_prompt` | Sends Slack alerts when Claude needs input |
 
 ### Utils
 
 Tools to help you build and debug hooks.
 
-| Tool | Language | Description |
-|------|----------|-------------|
-| [event-logger](hook-scripts/utils/event-logger.py) | Python | Logs all hook events to inspect payload structures |
+| Tool                                               | Language | Description                                        |
+| -------------------------------------------------- | -------- | -------------------------------------------------- |
+| [event-logger](hook-scripts/utils/event-logger.py) | Python   | Logs all hook events to inspect payload structures |
 
 > 💡 **Building a new hook?** Use `event-logger.py` to discover what data Claude Code provides for each event before writing your own hooks.
 
@@ -75,12 +76,14 @@ Tools to help you build and debug hooks.
 ## 🚀 Quick Start
 
 **1. Copy the hook script:**
+
 ```bash
 mkdir -p ~/.claude/hooks
 cp hook-scripts/pre-tool-use/block-dangerous-commands.js ~/.claude/hooks/
 ```
 
 **2. Add to `.claude/settings.json`:**
+
 ```json
 {
   "hooks": {
@@ -109,16 +112,16 @@ cp hook-scripts/pre-tool-use/block-dangerous-commands.js ~/.claude/hooks/
 
 Security hooks support configurable safety levels:
 
-| Level | What's Blocked | Use Case |
-|-------|----------------|----------|
-| `critical` | Catastrophic only (rm -rf ~, fork bombs, dd to disk) | Maximum flexibility |
-| `high` | + Risky (force push main, secrets exposure, git reset --hard) | **Recommended** |
-| `strict` | + Cautionary (any force push, sudo rm, docker prune) | Maximum safety |
+| Level      | What's Blocked                                                | Use Case            |
+| ---------- | ------------------------------------------------------------- | ------------------- |
+| `critical` | Catastrophic only (rm -rf ~, fork bombs, dd to disk)          | Maximum flexibility |
+| `high`     | + Risky (force push main, secrets exposure, git reset --hard) | **Recommended**     |
+| `strict`   | + Cautionary (any force push, sudo rm, docker prune)          | Maximum safety      |
 
 **To change:** Edit the `SAFETY_LEVEL` constant at the top of each hook.
 
 ```javascript
-const SAFETY_LEVEL = 'strict'; // or 'critical', 'high'
+const SAFETY_LEVEL = "strict"; // or 'critical', 'high'
 ```
 
 ---
@@ -136,6 +139,7 @@ node --test hook-scripts/tests/pre-tool-use/block-dangerous-commands.test.js
 ```
 
 **Test coverage:**
+
 - ✅ Unit tests for core functions
 - ✅ Integration tests for stdin/stdout flow
 - ✅ Config validation tests
@@ -159,20 +163,19 @@ Contributions welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 **Ideas for new hooks:**
 
-| Hook | Event | Description |
-|------|-------|-------------|
-| `protect-tests` | PreToolUse | Block test deletion/disabling |
-| `auto-format` | PostToolUse | Run prettier/black/gofmt after edits |
-| `branch-guard` | PreToolUse | Block changes on main/master branch |
-| `context-snapshot` | PreCompact | Preserve context before compaction |
-| `session-summary` | Stop | Generate summary on session end |
-| `ntfy-notify` | Notification | Free mobile push via [ntfy.sh](https://ntfy.sh) |
-| `discord-notify` | Notification | Discord webhook alerts |
-| `cost-tracker` | PostToolUse | Track token usage and estimate costs |
-| `tts-alerts` | Notification | Voice notifications via say/espeak |
-| `rules-injector` | UserPromptSubmit | Auto-inject CLAUDE.md rules |
-| `rate-limiter` | PreToolUse | Limit tool calls per minute |
-| `context-injector` | SessionStart | Inject project context on session start |
+| Hook               | Event            | Description                                     |
+| ------------------ | ---------------- | ----------------------------------------------- |
+| `protect-tests`    | PreToolUse       | Block test deletion/disabling                   |
+| `branch-guard`     | PreToolUse       | Block changes on main/master branch             |
+| `context-snapshot` | PreCompact       | Preserve context before compaction              |
+| `session-summary`  | Stop             | Generate summary on session end                 |
+| `ntfy-notify`      | Notification     | Free mobile push via [ntfy.sh](https://ntfy.sh) |
+| `discord-notify`   | Notification     | Discord webhook alerts                          |
+| `cost-tracker`     | PostToolUse      | Track token usage and estimate costs            |
+| `tts-alerts`       | Notification     | Voice notifications via say/espeak              |
+| `rules-injector`   | UserPromptSubmit | Auto-inject CLAUDE.md rules                     |
+| `rate-limiter`     | PreToolUse       | Limit tool calls per minute                     |
+| `context-injector` | SessionStart     | Inject project context on session start         |
 
 ---
 

--- a/hook-scripts/post-tool-use/format-code.js
+++ b/hook-scripts/post-tool-use/format-code.js
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+/**
+ * Format Code - PostToolUse Hook for Write|Edit
+ * Auto-formats files after Claude Code modifies them.
+ * Supports Python (ruff) and Markdown/YAML/JSON (prettier).
+ * Logs to: ~/.claude/hooks-logs/
+ *
+ * Benefits:
+ *   - No manual formatting needed after Claude edits files
+ *   - Consistent code style across AI-generated changes
+ *   - Supports Python and common config/documentation formats
+ *
+ * Setup in .claude/settings.json:
+ * {
+ *   "hooks": {
+ *     "PostToolUse": [{
+ *       "matcher": "Write|Edit",
+ *       "hooks": [{ "type": "command", "command": "node /path/to/format-code.js" }]
+ *     }]
+ *   }
+ * }
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const LOG_DIR = path.join(process.env.HOME, '.claude', 'hooks-logs');
+
+const FORMATTERS = {
+  '.py': {
+    name: 'ruff',
+    commands: (fp) => [
+      ['uv', 'run', 'ruff', 'check', '--fix', '--exit-zero', '--quiet', fp],
+      ['uv', 'run', 'ruff', 'format', '--quiet', fp],
+    ],
+  },
+  '.md':    { name: 'prettier', commands: (fp) => [['npx', '--yes', 'prettier', '--write', fp]] },
+  '.yaml':  { name: 'prettier', commands: (fp) => [['npx', '--yes', 'prettier', '--write', fp]] },
+  '.yml':   { name: 'prettier', commands: (fp) => [['npx', '--yes', 'prettier', '--write', fp]] },
+  '.json':  { name: 'prettier', commands: (fp) => [['npx', '--yes', 'prettier', '--write', fp]] },
+};
+
+function log(data) {
+  try {
+    if (!fs.existsSync(LOG_DIR)) fs.mkdirSync(LOG_DIR, { recursive: true });
+    const file = path.join(LOG_DIR, `${new Date().toISOString().slice(0, 10)}.jsonl`);
+    fs.appendFileSync(file, JSON.stringify({ ts: new Date().toISOString(), hook: 'format-code', ...data }) + '\n');
+  } catch {}
+}
+
+function getFormatter(filePath) {
+  const ext = path.extname(filePath).toLowerCase();
+  return FORMATTERS[ext] || null;
+}
+
+function formatFile(filePath, cwd, sessionId) {
+  const absPath = path.isAbsolute(filePath) ? filePath : path.join(cwd || process.cwd(), filePath);
+
+  if (!fs.existsSync(absPath)) {
+    log({ level: 'SKIP', reason: 'file not found', file: absPath, session_id: sessionId });
+    return { success: false, error: 'file not found' };
+  }
+
+  const formatter = getFormatter(absPath);
+  if (!formatter) {
+    log({ level: 'SKIP', reason: 'unsupported file type', file: absPath, session_id: sessionId });
+    return { success: false, error: 'unsupported file type' };
+  }
+
+  const dir = path.dirname(absPath);
+
+  for (const args of formatter.commands(absPath)) {
+    try {
+      const result = spawnSync(args[0], args.slice(1), { cwd: dir, stdio: 'pipe' });
+      if (result.status !== 0) {
+        const msg = result.stderr?.toString()?.trim() || `Process exited with code ${result.status}`;
+        log({ level: 'ERROR', formatter: formatter.name, file: absPath, error: msg, session_id: sessionId });
+        return { success: false, error: msg, formatter: formatter.name };
+      }
+    } catch (e) {
+      const msg = e.message;
+      log({ level: 'ERROR', formatter: formatter.name, file: absPath, error: msg, session_id: sessionId });
+      return { success: false, error: msg, formatter: formatter.name };
+    }
+  }
+
+  log({ level: 'FORMATTED', formatter: formatter.name, file: absPath, session_id: sessionId });
+  return { success: true, formatter: formatter.name };
+}
+
+async function main() {
+  let input = '';
+  for await (const chunk of process.stdin) input += chunk;
+
+  try {
+    const data = JSON.parse(input);
+    const { tool_name, tool_input, session_id, cwd } = data;
+
+    if (!['Write', 'Edit'].includes(tool_name)) {
+      return console.log('{}');
+    }
+
+    const workDir = cwd || process.cwd();
+
+    if (!tool_input?.file_path) {
+      log({ level: 'SKIP', reason: 'no file_path', tool: tool_name, session_id });
+      return console.log('{}');
+    }
+
+    const files = [tool_input.file_path];
+
+    for (const file of files) {
+      formatFile(file, workDir, session_id);
+    }
+
+    console.log('{}');
+  } catch (e) {
+    log({ level: 'ERROR', error: e.message });
+    console.log('{}');
+  }
+}
+
+if (require.main === module) {
+  main();
+} else {
+  module.exports = { getFormatter, formatFile, log, FORMATTERS };
+}

--- a/hook-scripts/post-tool-use/format-code.js
+++ b/hook-scripts/post-tool-use/format-code.js
@@ -5,11 +5,6 @@
  * Supports Python (ruff) and Markdown/YAML/JSON (prettier).
  * Logs to: ~/.claude/hooks-logs/
  *
- * Benefits:
- *   - No manual formatting needed after Claude edits files
- *   - Consistent code style across AI-generated changes
- *   - Supports Python and common config/documentation formats
- *
  * Setup in .claude/settings.json:
  * {
  *   "hooks": {
@@ -27,19 +22,18 @@ const { spawnSync } = require('child_process');
 
 const LOG_DIR = path.join(process.env.HOME, '.claude', 'hooks-logs');
 
+const PRETTIER_EXTS = new Set(['.md', '.yaml', '.yml', '.json']);
+
 const FORMATTERS = {
-  '.py': {
-    name: 'ruff',
-    commands: (fp) => [
-      ['uv', 'run', 'ruff', 'check', '--fix', '--exit-zero', '--quiet', fp],
-      ['uv', 'run', 'ruff', 'format', '--quiet', fp],
-    ],
-  },
-  '.md':    { name: 'prettier', commands: (fp) => [['npx', '--yes', 'prettier', '--write', fp]] },
-  '.yaml':  { name: 'prettier', commands: (fp) => [['npx', '--yes', 'prettier', '--write', fp]] },
-  '.yml':   { name: 'prettier', commands: (fp) => [['npx', '--yes', 'prettier', '--write', fp]] },
-  '.json':  { name: 'prettier', commands: (fp) => [['npx', '--yes', 'prettier', '--write', fp]] },
+  '.py': (fp) => [
+    ['uv', 'run', 'ruff', 'check', '--fix', '--exit-zero', '--quiet', fp],
+    ['uv', 'run', 'ruff', 'format', '--quiet', fp],
+  ],
 };
+
+for (const ext of PRETTIER_EXTS) {
+  FORMATTERS[ext] = (fp) => [['npx', '--yes', 'prettier', '--write', fp]];
+}
 
 function log(data) {
   try {
@@ -55,70 +49,61 @@ function getFormatter(filePath) {
 }
 
 function formatFile(filePath, cwd, sessionId) {
-  const absPath = path.isAbsolute(filePath) ? filePath : path.join(cwd || process.cwd(), filePath);
+  const absPath = path.isAbsolute(filePath) ? filePath : path.join(cwd, filePath);
 
   if (!fs.existsSync(absPath)) {
     log({ level: 'SKIP', reason: 'file not found', file: absPath, session_id: sessionId });
     return { success: false, error: 'file not found' };
   }
 
-  const formatter = getFormatter(absPath);
-  if (!formatter) {
+  const ext = path.extname(absPath).toLowerCase();
+  const getCommands = FORMATTERS[ext];
+  if (!getCommands) {
     log({ level: 'SKIP', reason: 'unsupported file type', file: absPath, session_id: sessionId });
     return { success: false, error: 'unsupported file type' };
   }
 
+  const formatterName = PRETTIER_EXTS.has(ext) ? 'prettier' : 'ruff';
   const dir = path.dirname(absPath);
 
-  for (const args of formatter.commands(absPath)) {
+  for (const args of getCommands(absPath)) {
     try {
       const result = spawnSync(args[0], args.slice(1), { cwd: dir, stdio: 'pipe' });
       if (result.status !== 0) {
-        const msg = result.stderr?.toString()?.trim() || `Process exited with code ${result.status}`;
-        log({ level: 'ERROR', formatter: formatter.name, file: absPath, error: msg, session_id: sessionId });
-        return { success: false, error: msg, formatter: formatter.name };
+        const msg = result.stderr?.toString().trim() || `Process exited with code ${result.status}`;
+        log({ level: 'ERROR', formatter: formatterName, file: absPath, error: msg, session_id: sessionId });
+        return { success: false, error: msg, formatter: formatterName };
       }
     } catch (e) {
-      const msg = e.message;
-      log({ level: 'ERROR', formatter: formatter.name, file: absPath, error: msg, session_id: sessionId });
-      return { success: false, error: msg, formatter: formatter.name };
+      log({ level: 'ERROR', formatter: formatterName, file: absPath, error: e.message, session_id: sessionId });
+      return { success: false, error: e.message, formatter: formatterName };
     }
   }
 
-  log({ level: 'FORMATTED', formatter: formatter.name, file: absPath, session_id: sessionId });
-  return { success: true, formatter: formatter.name };
+  log({ level: 'FORMATTED', formatter: formatterName, file: absPath, session_id: sessionId });
+  return { success: true, formatter: formatterName };
 }
 
 async function main() {
   let input = '';
   for await (const chunk of process.stdin) input += chunk;
 
+  let data;
   try {
-    const data = JSON.parse(input);
-    const { tool_name, tool_input, session_id, cwd } = data;
-
-    if (!['Write', 'Edit'].includes(tool_name)) {
-      return console.log('{}');
-    }
-
-    const workDir = cwd || process.cwd();
-
-    if (!tool_input?.file_path) {
-      log({ level: 'SKIP', reason: 'no file_path', tool: tool_name, session_id });
-      return console.log('{}');
-    }
-
-    const files = [tool_input.file_path];
-
-    for (const file of files) {
-      formatFile(file, workDir, session_id);
-    }
-
-    console.log('{}');
+    data = JSON.parse(input);
   } catch (e) {
     log({ level: 'ERROR', error: e.message });
-    console.log('{}');
+    return console.log('{}');
   }
+
+  const { tool_name, tool_input, session_id, cwd } = data;
+
+  if (!['Write', 'Edit'].includes(tool_name) || !tool_input?.file_path) {
+    return console.log('{}');
+  }
+
+  formatFile(tool_input.file_path, cwd || process.cwd(), session_id);
+  console.log('{}');
 }
 
 if (require.main === module) {

--- a/hook-scripts/post-tool-use/format-code.js
+++ b/hook-scripts/post-tool-use/format-code.js
@@ -22,7 +22,7 @@ const { spawnSync } = require('child_process');
 
 const LOG_DIR = path.join(process.env.HOME, '.claude', 'hooks-logs');
 
-const PRETTIER_EXTS = new Set(['.md', '.yaml', '.yml', '.json']);
+const PRETTIER_EXTS = new Set(['.js', '.ts', '.json', '.md', '.yaml', '.yml', '.html']);
 
 const FORMATTERS = {
   '.py': (fp) => [

--- a/hook-scripts/tests/post-tool-use/format-code.test.js
+++ b/hook-scripts/tests/post-tool-use/format-code.test.js
@@ -1,0 +1,309 @@
+#!/usr/bin/env node
+/**
+ * Tests for format-code.js
+ *
+ * Run: node --test hook-scripts/tests/post-tool-use/format-code.test.js
+ * Or:  npm test
+ */
+
+const { describe, it, afterEach } = require('node:test');
+const assert = require('node:assert');
+const { spawn } = require('node:child_process');
+const path = require('node:path');
+const fs = require('node:fs');
+const os = require('node:os');
+
+const { getFormatter, formatFile, log, FORMATTERS } = require('../../post-tool-use/format-code.js');
+
+const SCRIPT_PATH = path.join(__dirname, '../../post-tool-use/format-code.js');
+
+// ----------------------------------------------------------------------------
+// Test helpers
+// ----------------------------------------------------------------------------
+
+const tmpDirs = [];
+
+afterEach(() => {
+  for (const d of tmpDirs) {
+    fs.rmSync(d, { recursive: true, force: true });
+  }
+  tmpDirs.length = 0;
+});
+
+function tmpFile(ext, content) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'format-code-test-'));
+  tmpDirs.push(dir);
+  const filePath = path.join(dir, `test${ext}`);
+  fs.writeFileSync(filePath, content || '');
+  return filePath;
+}
+
+function readContent(filePath) {
+  return fs.readFileSync(filePath, 'utf-8');
+}
+
+function runHook(hookData) {
+  return new Promise((resolve, reject) => {
+    const child = spawn('node', [SCRIPT_PATH]);
+    let stdout = '';
+
+    child.stdout.on('data', (data) => { stdout += data; });
+    child.on('close', (code) => {
+      try {
+        resolve({ code, output: JSON.parse(stdout.trim() || '{}') });
+      } catch (e) {
+        reject(new Error(`Failed to parse output: ${stdout}`));
+      }
+    });
+
+    child.stdin.write(JSON.stringify(hookData));
+    child.stdin.end();
+  });
+}
+
+// ----------------------------------------------------------------------------
+// Unit Tests - getFormatter
+// ----------------------------------------------------------------------------
+
+describe('Unit: getFormatter()', () => {
+  it('returns ruff for .py files', () => {
+    const result = getFormatter('/path/to/file.py');
+    assert.strictEqual(result.name, 'ruff');
+    assert.ok(Array.isArray(result.commands('/path/to/file.py')));
+  });
+
+  it('returns prettier for .md files', () => {
+    assert.strictEqual(getFormatter('/path/to/readme.md').name, 'prettier');
+  });
+
+  it('returns prettier for .yaml files', () => {
+    assert.strictEqual(getFormatter('/path/to/config.yaml').name, 'prettier');
+  });
+
+  it('returns prettier for .yml files', () => {
+    assert.strictEqual(getFormatter('/path/to/config.yml').name, 'prettier');
+  });
+
+  it('returns prettier for .json files', () => {
+    assert.strictEqual(getFormatter('/path/to/package.json').name, 'prettier');
+  });
+
+  it('returns null for unsupported extensions', () => {
+    assert.strictEqual(getFormatter('/path/to/file.js'), null);
+    assert.strictEqual(getFormatter('/path/to/file.ts'), null);
+    assert.strictEqual(getFormatter('/path/to/file.go'), null);
+    assert.strictEqual(getFormatter('/path/to/file.txt'), null);
+  });
+
+  it('handles uppercase extensions', () => {
+    assert.strictEqual(getFormatter('/path/to/file.PY').name, 'ruff');
+    assert.strictEqual(getFormatter('/path/to/file.MD').name, 'prettier');
+    assert.strictEqual(getFormatter('/path/to/file.JSON').name, 'prettier');
+  });
+
+  it('handles extensions with paths containing dots', () => {
+    assert.strictEqual(getFormatter('/path/to/some.config.file.yaml').name, 'prettier');
+  });
+});
+
+// ----------------------------------------------------------------------------
+// Unit Tests - formatFile
+// ----------------------------------------------------------------------------
+
+describe('Unit: formatFile()', () => {
+  it('returns error for non-existent file', () => {
+    const result = formatFile('/nonexistent/path/file.py', '/tmp', 'test-session');
+    assert.strictEqual(result.success, false);
+    assert.strictEqual(result.error, 'file not found');
+  });
+
+  it('returns error for unsupported file type', () => {
+    const fp = tmpFile('.txt', 'hello world');
+    const result = formatFile(fp, '/tmp', 'test-session');
+    assert.strictEqual(result.success, false);
+    assert.strictEqual(result.error, 'unsupported file type');
+  });
+
+  it('returns error for invalid Python syntax', () => {
+    const fp = tmpFile('.py', 'def broken(\n');
+    const result = formatFile(fp, '/tmp', 'test-session');
+    assert.strictEqual(result.success, false);
+    assert.strictEqual(result.formatter, 'ruff');
+  });
+
+  it('formats .py files with ruff and fixes spacing', () => {
+    const fp = tmpFile('.py', 'x=1\n');
+    const result = formatFile(fp, '/tmp', 'test-session');
+    assert.strictEqual(result.success, true);
+    assert.strictEqual(result.formatter, 'ruff');
+    const content = readContent(fp);
+    assert.ok(content.includes('x = 1'), `Expected ruff to add spaces around '=' but got: ${JSON.stringify(content)}`);
+  });
+
+  it('formats .md files with prettier', () => {
+    const fp = tmpFile('.md', '# Hello\n');
+    const result = formatFile(fp, '/tmp', 'test-session');
+    assert.strictEqual(result.success, true);
+    assert.strictEqual(result.formatter, 'prettier');
+  });
+
+  it('formats .json files with prettier', () => {
+    const fp = tmpFile('.json', '{"a":1}');
+    const result = formatFile(fp, '/tmp', 'test-session');
+    assert.strictEqual(result.success, true);
+    assert.strictEqual(result.formatter, 'prettier');
+    const content = readContent(fp);
+    assert.ok(content.includes('"a": 1'), `Expected prettier to add space after colon but got: ${JSON.stringify(content)}`);
+  });
+
+  it('resolves relative paths using cwd', () => {
+    const fp = tmpFile('.py', 'x=1\n');
+    const relPath = path.basename(fp);
+    const result = formatFile(relPath, path.dirname(fp), 'test-session');
+    assert.strictEqual(result.success, true);
+  });
+});
+
+// ----------------------------------------------------------------------------
+// Integration Tests - stdin/stdout hook flow
+// ----------------------------------------------------------------------------
+
+describe('Integration: stdin/stdout hook flow', () => {
+  it('formats .py file via Write tool and returns {}', async () => {
+    const fp = tmpFile('.py', 'x=1\n');
+    const { code, output } = await runHook({
+      tool_name: 'Write',
+      tool_input: { file_path: fp },
+      session_id: 'test-session',
+      cwd: '/tmp',
+    });
+    assert.strictEqual(code, 0);
+    assert.deepStrictEqual(output, {});
+    const content = readContent(fp);
+    assert.ok(content.includes('x = 1'), `Expected formatting but got: ${JSON.stringify(content)}`);
+  });
+
+  it('formats .json file via Edit tool and returns {}', async () => {
+    const fp = tmpFile('.json', '{"a":1}');
+    const { code, output } = await runHook({
+      tool_name: 'Edit',
+      tool_input: { file_path: fp },
+      session_id: 'test-session',
+      cwd: '/tmp',
+    });
+    assert.strictEqual(code, 0);
+    assert.deepStrictEqual(output, {});
+    const content = readContent(fp);
+    assert.ok(content.includes('"a": 1'), `Expected formatting but got: ${JSON.stringify(content)}`);
+  });
+
+  it('handles filenames with shell characters safely', async () => {
+    const maliciousName = 'test$(touch HACKED).py';
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'format-code-sec-'));
+    tmpDirs.push(dir);
+    const fp = path.join(dir, maliciousName);
+    fs.writeFileSync(fp, 'x=1\n');
+
+    const { code, output } = await runHook({
+      tool_name: 'Write',
+      tool_input: { file_path: fp },
+      session_id: 'test-session',
+      cwd: dir,
+    });
+
+    assert.strictEqual(code, 0);
+    assert.deepStrictEqual(output, {});
+    assert.strictEqual(fs.existsSync(path.join(dir, 'HACKED')), false, 'Shell injection triggered: HACKED file created');
+
+    const content = readContent(fp);
+    assert.ok(content.includes('x = 1'), 'File should still be processed');
+  });
+
+  it('returns {} for non-matching tool (Read)', async () => {
+    const { code, output } = await runHook({
+      tool_name: 'Read',
+      tool_input: { file_path: '/tmp/test.py' },
+      session_id: 'test-session',
+      cwd: '/tmp',
+    });
+    assert.strictEqual(code, 0);
+    assert.deepStrictEqual(output, {});
+  });
+
+  it('returns {} for non-matching tool (Bash)', async () => {
+    const { code, output } = await runHook({
+      tool_name: 'Bash',
+      tool_input: { command: 'ls' },
+      session_id: 'test-session',
+      cwd: '/tmp',
+    });
+    assert.strictEqual(code, 0);
+    assert.deepStrictEqual(output, {});
+  });
+
+  it('returns {} for malformed JSON gracefully', async () => {
+    const child = spawn('node', [SCRIPT_PATH]);
+    let stdout = '';
+
+    const result = await new Promise((resolve) => {
+      child.stdout.on('data', (data) => { stdout += data; });
+      child.on('close', (code) => resolve({ code, output: stdout.trim() }));
+      child.stdin.write('not valid json');
+      child.stdin.end();
+    });
+
+    assert.strictEqual(result.output, '{}');
+  });
+
+  it('returns {} when no file_path provided', async () => {
+    const { code, output } = await runHook({
+      tool_name: 'Write',
+      tool_input: {},
+      session_id: 'test-session',
+      cwd: '/tmp',
+    });
+    assert.strictEqual(code, 0);
+    assert.deepStrictEqual(output, {});
+  });
+
+  it('returns {} for non-existent file_path', async () => {
+    const { code, output } = await runHook({
+      tool_name: 'Write',
+      tool_input: { file_path: '/tmp/nonexistent-format-code-test.py' },
+      session_id: 'test-session',
+      cwd: '/tmp',
+    });
+    assert.strictEqual(code, 0);
+    assert.deepStrictEqual(output, {});
+  });
+});
+
+// ----------------------------------------------------------------------------
+// Config Tests - validate FORMATTERS structure
+// ----------------------------------------------------------------------------
+
+describe('Config: FORMATTERS structure', () => {
+  it('has valid extensions as keys', () => {
+    const exts = Object.keys(FORMATTERS);
+    assert.ok(exts.length > 0);
+    for (const ext of exts) {
+      assert.ok(ext.startsWith('.'), `Extension should start with dot: ${ext}`);
+    }
+  });
+
+  it('has name and commands for each formatter', () => {
+    for (const [ext, fmt] of Object.entries(FORMATTERS)) {
+      assert.ok(typeof fmt.name === 'string', `Formatter ${ext} missing name`);
+      assert.ok(typeof fmt.commands === 'function', `Formatter ${ext} missing commands function`);
+      const cmds = fmt.commands(`/tmp/test${ext}`);
+      assert.ok(Array.isArray(cmds), `commands for ${ext} should return array`);
+      assert.ok(cmds.length > 0, `commands for ${ext} should have at least one command`);
+    }
+  });
+
+  it('exports expected functions', () => {
+    assert.strictEqual(typeof getFormatter, 'function');
+    assert.strictEqual(typeof formatFile, 'function');
+    assert.strictEqual(typeof log, 'function');
+  });
+});

--- a/hook-scripts/tests/post-tool-use/format-code.test.js
+++ b/hook-scripts/tests/post-tool-use/format-code.test.js
@@ -68,24 +68,24 @@ function runHook(hookData) {
 describe('Unit: getFormatter()', () => {
   it('returns ruff for .py files', () => {
     const result = getFormatter('/path/to/file.py');
-    assert.strictEqual(result.name, 'ruff');
-    assert.ok(Array.isArray(result.commands('/path/to/file.py')));
+    assert.strictEqual(typeof result, 'function');
+    assert.ok(Array.isArray(result('/path/to/file.py')));
   });
 
   it('returns prettier for .md files', () => {
-    assert.strictEqual(getFormatter('/path/to/readme.md').name, 'prettier');
+    assert.strictEqual(typeof getFormatter('/path/to/readme.md'), 'function');
   });
 
   it('returns prettier for .yaml files', () => {
-    assert.strictEqual(getFormatter('/path/to/config.yaml').name, 'prettier');
+    assert.strictEqual(typeof getFormatter('/path/to/config.yaml'), 'function');
   });
 
   it('returns prettier for .yml files', () => {
-    assert.strictEqual(getFormatter('/path/to/config.yml').name, 'prettier');
+    assert.strictEqual(typeof getFormatter('/path/to/config.yml'), 'function');
   });
 
   it('returns prettier for .json files', () => {
-    assert.strictEqual(getFormatter('/path/to/package.json').name, 'prettier');
+    assert.strictEqual(typeof getFormatter('/path/to/package.json'), 'function');
   });
 
   it('returns null for unsupported extensions', () => {
@@ -96,13 +96,13 @@ describe('Unit: getFormatter()', () => {
   });
 
   it('handles uppercase extensions', () => {
-    assert.strictEqual(getFormatter('/path/to/file.PY').name, 'ruff');
-    assert.strictEqual(getFormatter('/path/to/file.MD').name, 'prettier');
-    assert.strictEqual(getFormatter('/path/to/file.JSON').name, 'prettier');
+    assert.strictEqual(typeof getFormatter('/path/to/file.PY'), 'function');
+    assert.strictEqual(typeof getFormatter('/path/to/file.MD'), 'function');
+    assert.strictEqual(typeof getFormatter('/path/to/file.JSON'), 'function');
   });
 
   it('handles extensions with paths containing dots', () => {
-    assert.strictEqual(getFormatter('/path/to/some.config.file.yaml').name, 'prettier');
+    assert.strictEqual(typeof getFormatter('/path/to/some.config.file.yaml'), 'function');
   });
 });
 
@@ -291,11 +291,10 @@ describe('Config: FORMATTERS structure', () => {
     }
   });
 
-  it('has name and commands for each formatter', () => {
-    for (const [ext, fmt] of Object.entries(FORMATTERS)) {
-      assert.ok(typeof fmt.name === 'string', `Formatter ${ext} missing name`);
-      assert.ok(typeof fmt.commands === 'function', `Formatter ${ext} missing commands function`);
-      const cmds = fmt.commands(`/tmp/test${ext}`);
+  it('has commands for each formatter', () => {
+    for (const [ext, getCmds] of Object.entries(FORMATTERS)) {
+      assert.ok(typeof getCmds === 'function', `Formatter ${ext} missing commands function`);
+      const cmds = getCmds(`/tmp/test${ext}`);
       assert.ok(Array.isArray(cmds), `commands for ${ext} should return array`);
       assert.ok(cmds.length > 0, `commands for ${ext} should have at least one command`);
     }

--- a/hook-scripts/tests/post-tool-use/format-code.test.js
+++ b/hook-scripts/tests/post-tool-use/format-code.test.js
@@ -72,6 +72,14 @@ describe('Unit: getFormatter()', () => {
     assert.ok(Array.isArray(result('/path/to/file.py')));
   });
 
+  it('returns prettier for .js files', () => {
+    assert.strictEqual(typeof getFormatter('/path/to/file.js'), 'function');
+  });
+
+  it('returns prettier for .ts files', () => {
+    assert.strictEqual(typeof getFormatter('/path/to/file.ts'), 'function');
+  });
+
   it('returns prettier for .md files', () => {
     assert.strictEqual(typeof getFormatter('/path/to/readme.md'), 'function');
   });
@@ -88,9 +96,11 @@ describe('Unit: getFormatter()', () => {
     assert.strictEqual(typeof getFormatter('/path/to/package.json'), 'function');
   });
 
+  it('returns prettier for .html files', () => {
+    assert.strictEqual(typeof getFormatter('/path/to/index.html'), 'function');
+  });
+
   it('returns null for unsupported extensions', () => {
-    assert.strictEqual(getFormatter('/path/to/file.js'), null);
-    assert.strictEqual(getFormatter('/path/to/file.ts'), null);
     assert.strictEqual(getFormatter('/path/to/file.go'), null);
     assert.strictEqual(getFormatter('/path/to/file.txt'), null);
   });


### PR DESCRIPTION
Introduces a new hook that automatically formats files after Write or Edit tool use.
  - Supports Python via ruff.
  - Supports JS, TS, HTML, JSON, MD, and YAML via prettier.
  - Includes a comprehensive test suite and updated documentation.
