### PR TITLE
ci: deploy landing page to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,44 @@
+name: Deploy landing page
+
+# Publishes site/ to GitHub Pages. The site/ folder becomes the Pages root,
+# so site/index.html is served at the site URL root.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'site/**'
+      - '.github/workflows/deploy-pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one deploy at a time; don't cancel an in-progress publish.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload site/ artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that publishes the `site/` landing page (merged in #15) to **GitHub Pages**.

- Triggers on push to `main` touching `site/**` (and manual `workflow_dispatch`).
- Uses the official Pages actions: `configure-pages` → `upload-pages-artifact` (path: `site`) → `deploy-pages@v4`.
- `site/index.html` is served at the Pages URL root → https://karanb192.github.io/claude-code-hooks/

## Why a workflow (not classic Pages)

Classic Pages only serves from the repo root or `/docs`, not `/site`. A workflow lets us keep the page where it lives and still deploy it.

## Note

Pages **Source** is already set to **GitHub Actions** (enabled via API). The first deploy runs automatically when this merges to `main`.

## Test plan
- [x] YAML validated; artifact path points at `site/`.
- [ ] On merge: workflow runs, Pages goes live at the URL above.