### PR TITLE
docs: author section with site + OWASP talk link

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,14 @@ Contributions welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 ---
 
+## 👤 Author
+
+Built by [Karan Bansal](https://karanbansal.in), Head of AI at ArmorCode. These hooks are the basis of my OWASP GenAI Summit talk, [Hardening AI Coding Agents with Hooks](https://karanbansal.in/talks/) (slides and recording there).
+
+I write about Claude Code, MCP, and production agentic AI at [karanbansal.in/blog](https://karanbansal.in/blog/).
+
+---
+
 ## 📄 License
 
 MIT © [karanb192](https://github.com/karanb192)


### PR DESCRIPTION
Adds an author section linking karanbansal.in, the blog, and the OWASP GenAI Summit talk (Hardening AI Coding Agents with Hooks) whose slides and recording are hosted on the site. The talk is directly about this repo, so it doubles as documentation.