### PR TITLE
Add protect-tests hook: block the fake-green failure mode (deleting/disabling tests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Runs **before** Claude executes a tool. Can block or modify the operation.
 | [block-dangerous-commands](hook-scripts/pre-tool-use/block-dangerous-commands.js) | `Bash`                    | Blocks dangerous shell commands (rm -rf ~, fork bombs, curl\|sh) |
 | [protect-secrets](hook-scripts/pre-tool-use/protect-secrets.js)                   | `Read\|Edit\|Write\|Bash` | Prevents reading/modifying/exfiltrating sensitive files          |
 | [git-safety](hook-scripts/pre-tool-use/git-safety.js)                             | `Bash`                    | Branch-aware git guardrails + destructive gh CLI protection      |
+| [protect-tests](hook-scripts/pre-tool-use/protect-tests.js)                       | `Bash\|Edit\|MultiEdit\|Write` | Stops "fake green": blocks deleting, renaming-away, or skip/xfail-disabling tests |
 
 ### Post-Tool-Use
 
@@ -166,7 +167,6 @@ Contributions welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 | Hook               | Event            | Description                                     |
 | ------------------ | ---------------- | ----------------------------------------------- |
-| `protect-tests`    | PreToolUse       | Block test deletion/disabling                   |
 | `context-snapshot` | PreCompact       | Preserve context before compaction              |
 | `session-summary`  | Stop             | Generate summary on session end                 |
 | `ntfy-notify`      | Notification     | Free mobile push via [ntfy.sh](https://ntfy.sh) |

--- a/hook-scripts/pre-tool-use/protect-tests.js
+++ b/hook-scripts/pre-tool-use/protect-tests.js
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+/**
+ * Protect Tests - PreToolUse Hook for Bash|Edit|MultiEdit|Write
+ * Blocks the "fake green" failure mode: an agent that makes a suite pass by
+ * deleting, renaming-away, or disabling (skip/xfail/ignore) test cases instead
+ * of fixing the code. Logs to: ~/.claude/hooks-logs/
+ *
+ * SAFETY_LEVEL: 'critical' | 'high' | 'strict'
+ *   critical - deleting test files or whole test directories (rm / git rm)
+ *   high     - + renaming a test file to a disabled name, + introducing a
+ *              skip/xfail/ignore marker into an existing test (Edit/MultiEdit)
+ *   strict   - + writing a whole test file that is already skipped (Write)
+ *
+ * It does NOT block writing new, real tests, refactor-renaming a test to another
+ * test name, or editing test bodies — only removal and disabling.
+ *
+ * Setup in .claude/settings.json:
+ * {
+ *   "hooks": {
+ *     "PreToolUse": [{
+ *       "matcher": "Bash|Edit|MultiEdit|Write",
+ *       "hooks": [{ "type": "command", "command": "node /path/to/protect-tests.js" }]
+ *     }]
+ *   }
+ * }
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const SAFETY_LEVEL = 'high';
+
+const LEVELS = { critical: 1, high: 2, strict: 3 };
+const EMOJIS = { critical: '🚨', high: '⛔', strict: '⚠️' };
+const LOG_DIR = path.join(process.env.HOME || '/tmp', '.claude', 'hooks-logs');
+
+// A path that looks like a test file (many languages / conventions).
+const TEST_PATH = new RegExp(
+  [
+    '(^|/)(tests?|__tests__|spec|specs)/',        // inside a test directory
+    '(^|/)test_[^/]+\\.py$',                        // pytest / unittest
+    '_test\\.(py|go|rb|js|jsx|ts|tsx|mjs|cjs)$',    // *_test.*
+    '\\.(test|spec)\\.(js|jsx|ts|tsx|mjs|cjs)$',    // *.test.* / *.spec.*
+    '(^|/)[^/]+_spec\\.rb$',                        // rspec
+    '(^|/)[^/]*Test\\.(java|kt|cs)$',               // JUnit / xUnit
+    '(^|/)Test[^/]*\\.(java|kt|cs)$',
+  ].join('|'),
+  'i'
+);
+
+// The same, but as it would appear as a token inside a shell command.
+const TEST_TOKEN =
+  /(test_[\w.-]+\.\w+|[\w.-]+_test\.\w+|[\w.-]+\.(test|spec)\.\w+|[\w.-]+_spec\.rb|(^|[\s'"/])(tests?|__tests__|specs?)\/)/;
+
+const DELETE_VERB = /(\brm\b|\bunlink\b|\bshred\b|\btrash\b|\bgit\s+rm\b)/;
+const RENAME_VERB = /\bmv\b/;
+const DISABLED_DEST = /(\.bak|\.old|\.orig|\.disabled|\.skip|\.ignore|\.tmp|~)(["'\s]|$)/i;
+
+// Markers that turn an existing test off in place.
+const SKIP_MARKERS = [
+  /@pytest\.mark\.(skip|xfail)/,          // pytest
+  /@unittest\.skip/,                       // unittest
+  /\bpytest\.skip\s*\(/,
+  /@Disabled\b/,                           // JUnit 5
+  /@Ignore\b/,                             // JUnit 4 / TestNG
+  /\b(it|test|describe|context)\.skip\s*\(/, // jest / mocha / vitest
+  /\bx(it|describe|test|context)\s*\(/,      // xit / xdescribe ...
+  /\bt\.Skip(Now)?\s*\(/,                   // Go
+  /#\[ignore\]/,                           // Rust
+  /\[Ignore\]/,                            // NUnit / MSTest
+];
+
+function log(data) {
+  try {
+    if (!fs.existsSync(LOG_DIR)) fs.mkdirSync(LOG_DIR, { recursive: true });
+    const file = path.join(LOG_DIR, `${new Date().toISOString().slice(0, 10)}.jsonl`);
+    fs.appendFileSync(file, JSON.stringify({ ts: new Date().toISOString(), ...data }) + '\n');
+  } catch {}
+}
+
+function addedMarker(oldStr, newStr) {
+  const before = oldStr || '';
+  for (const m of SKIP_MARKERS) {
+    if (m.test(newStr) && !m.test(before)) return true;
+  }
+  return false;
+}
+
+// Returns { blocked, id, level, reason } — pure, so it is unit-testable.
+function checkTool(toolName, toolInput = {}, safetyLevel = SAFETY_LEVEL) {
+  const threshold = LEVELS[safetyLevel] || 2;
+  const allow = () => ({ blocked: false });
+  const deny = (level, id, reason) =>
+    LEVELS[level] <= threshold ? { blocked: true, id, level, reason } : allow();
+
+  if (toolName === 'Bash') {
+    const cmd = toolInput.command || '';
+    if (!TEST_TOKEN.test(cmd)) return allow();
+    if (DELETE_VERB.test(cmd)) return deny('critical', 'delete-test', 'deleting test file(s) or test directory');
+    if (RENAME_VERB.test(cmd) && DISABLED_DEST.test(cmd))
+      return deny('high', 'rename-test', 'renaming a test file to a disabled name');
+    return allow();
+  }
+
+  if (toolName === 'Edit') {
+    if (TEST_PATH.test(toolInput.file_path || '') && addedMarker(toolInput.old_string, toolInput.new_string))
+      return deny('high', 'skip-test', 'adding a skip/xfail/ignore marker to an existing test');
+    return allow();
+  }
+
+  if (toolName === 'MultiEdit') {
+    if (TEST_PATH.test(toolInput.file_path || '')) {
+      for (const e of toolInput.edits || []) {
+        if (addedMarker(e.old_string, e.new_string))
+          return deny('high', 'skip-test', 'adding a skip/xfail/ignore marker to an existing test');
+      }
+    }
+    return allow();
+  }
+
+  if (toolName === 'Write') {
+    if (TEST_PATH.test(toolInput.file_path || '') && addedMarker('', toolInput.content || ''))
+      return deny('strict', 'write-skipped-test', 'writing a test file that is already skipped/ignored');
+    return allow();
+  }
+
+  return allow();
+}
+
+async function main() {
+  let input = '';
+  for await (const chunk of process.stdin) input += chunk;
+
+  try {
+    const data = JSON.parse(input);
+    const { tool_name, tool_input, session_id, cwd, permission_mode } = data;
+    const result = checkTool(tool_name, tool_input || {});
+
+    if (result.blocked) {
+      log({ level: 'BLOCKED', id: result.id, priority: result.level, tool: tool_name, session_id, cwd, permission_mode });
+      return console.log(JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'deny',
+          permissionDecisionReason: `${EMOJIS[result.level]} [${result.id}] ${result.reason}. Fix the code, don't disable the test — or run this manually if the removal is intentional.`
+        }
+      }));
+    }
+    console.log('{}');
+  } catch (e) {
+    log({ level: 'ERROR', error: e.message });
+    console.log('{}');
+  }
+}
+
+if (require.main === module) {
+  main();
+} else {
+  module.exports = { SKIP_MARKERS, TEST_PATH, LEVELS, SAFETY_LEVEL, checkTool };
+}

--- a/hook-scripts/tests/pre-tool-use/protect-tests.test.js
+++ b/hook-scripts/tests/pre-tool-use/protect-tests.test.js
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+/**
+ * Tests for protect-tests.js
+ *
+ * Run: node --test hook-scripts/tests/pre-tool-use/protect-tests.test.js
+ * Or:  npm test
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { spawn } = require('node:child_process');
+const path = require('node:path');
+
+const { checkTool } = require('../../pre-tool-use/protect-tests.js');
+
+const SCRIPT_PATH = path.join(__dirname, '../../pre-tool-use/protect-tests.js');
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function shouldBlock(toolName, toolInput, expectedId = null, safetyLevel = undefined) {
+  const result = checkTool(toolName, toolInput, safetyLevel);
+  assert.strictEqual(result.blocked, true, `Expected BLOCKED but was ALLOWED: ${JSON.stringify(toolInput)}`);
+  if (expectedId) {
+    assert.strictEqual(result.id, expectedId, `Expected id '${expectedId}' but got '${result.id}'`);
+  }
+}
+
+function shouldAllow(toolName, toolInput, safetyLevel = undefined) {
+  const result = checkTool(toolName, toolInput, safetyLevel);
+  assert.strictEqual(result.blocked, false, `Expected ALLOWED but was BLOCKED by '${result.id}': ${JSON.stringify(toolInput)}`);
+}
+
+function runHook(payload) {
+  return new Promise((resolve, reject) => {
+    const child = spawn('node', [SCRIPT_PATH]);
+    let stdout = '';
+    child.stdout.on('data', (d) => { stdout += d; });
+    child.on('close', () => {
+      try { resolve(JSON.parse(stdout.trim())); }
+      catch (e) { reject(new Error(`Failed to parse output: ${stdout}`)); }
+    });
+    child.stdin.write(JSON.stringify({ session_id: 'test', cwd: '/tmp', permission_mode: 'default', ...payload }));
+    child.stdin.end();
+  });
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Unit Tests - deleting tests via Bash
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Bash: deleting test files', () => {
+  it('blocks rm of a pytest file', () => shouldBlock('Bash', { command: 'rm test_auth.py' }, 'delete-test'));
+  it('blocks rm -rf of a tests directory', () => shouldBlock('Bash', { command: 'rm -rf tests/' }, 'delete-test'));
+  it('blocks rm of a jest spec', () => shouldBlock('Bash', { command: 'rm src/auth.test.ts' }, 'delete-test'));
+  it('blocks rm of a go test', () => shouldBlock('Bash', { command: 'rm handler_test.go' }, 'delete-test'));
+  it('blocks git rm of a test file', () => shouldBlock('Bash', { command: 'git rm test_payment.py' }, 'delete-test'));
+  it('blocks rm of __tests__ dir', () => shouldBlock('Bash', { command: 'rm -r src/__tests__/' }, 'delete-test'));
+});
+
+describe('Bash: renaming tests away', () => {
+  it('blocks mv test to .bak', () => shouldBlock('Bash', { command: 'mv test_auth.py test_auth.py.bak' }, 'rename-test'));
+  it('blocks mv test to .disabled', () => shouldBlock('Bash', { command: 'mv auth.test.ts auth.test.ts.disabled' }, 'rename-test'));
+});
+
+describe('Bash: legitimate commands are allowed', () => {
+  it('allows running the tests', () => shouldAllow('Bash', { command: 'pytest tests/' }));
+  it('allows npm test', () => shouldAllow('Bash', { command: 'npm test' }));
+  it('allows rm of non-test artifacts', () => shouldAllow('Bash', { command: 'rm -rf node_modules' }));
+  it('allows rm of build output', () => shouldAllow('Bash', { command: 'rm -rf dist build .pytest_cache' }));
+  it('allows creating a test dir', () => shouldAllow('Bash', { command: 'mkdir -p tests/unit' }));
+  it('allows go test', () => shouldAllow('Bash', { command: 'go test ./...' }));
+  it('allows refactor rename to another test name', () => shouldAllow('Bash', { command: 'mv test_old.py test_new.py' }));
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Unit Tests - disabling tests via Edit
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Edit: disabling tests in place', () => {
+  it('blocks adding @pytest.mark.skip', () => shouldBlock('Edit', {
+    file_path: 'tests/test_auth.py',
+    old_string: 'def test_login():',
+    new_string: '@pytest.mark.skip\ndef test_login():'
+  }, 'skip-test'));
+
+  it('blocks adding @pytest.mark.xfail', () => shouldBlock('Edit', {
+    file_path: 'test_math.py',
+    old_string: 'def test_add():',
+    new_string: '@pytest.mark.xfail\ndef test_add():'
+  }, 'skip-test'));
+
+  it('blocks converting it() to it.skip()', () => shouldBlock('Edit', {
+    file_path: 'src/auth.test.js',
+    old_string: "it('logs in', () => {",
+    new_string: "it.skip('logs in', () => {"
+  }, 'skip-test'));
+
+  it('blocks converting it() to xit()', () => shouldBlock('Edit', {
+    file_path: 'src/auth.spec.ts',
+    old_string: "it('logs in', () => {",
+    new_string: "xit('logs in', () => {"
+  }, 'skip-test'));
+
+  it('blocks adding t.Skip in Go', () => shouldBlock('Edit', {
+    file_path: 'handler_test.go',
+    old_string: 'func TestHandler(t *testing.T) {',
+    new_string: 'func TestHandler(t *testing.T) {\n\tt.Skip("flaky")'
+  }, 'skip-test'));
+
+  it('blocks adding @Disabled in JUnit', () => shouldBlock('Edit', {
+    file_path: 'src/AuthTest.java',
+    old_string: '  @Test',
+    new_string: '  @Disabled\n  @Test'
+  }, 'skip-test'));
+});
+
+describe('Edit: legitimate edits are allowed', () => {
+  it('allows editing a test body', () => shouldAllow('Edit', {
+    file_path: 'tests/test_auth.py',
+    old_string: 'assert login() == True',
+    new_string: 'assert login() is True'
+  }));
+  it('allows editing non-test files even with skip-looking text', () => shouldAllow('Edit', {
+    file_path: 'src/app.py',
+    old_string: 'x = 1',
+    new_string: 'x = 2  # @pytest.mark.skip in a comment, not a test file'
+  }));
+  it('allows removing a skip marker (re-enabling a test)', () => shouldAllow('Edit', {
+    file_path: 'tests/test_auth.py',
+    old_string: '@pytest.mark.skip\ndef test_login():',
+    new_string: 'def test_login():'
+  }));
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Safety levels
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Safety levels', () => {
+  it('critical level still blocks deletion', () => shouldBlock('Bash', { command: 'rm test_x.py' }, 'delete-test', 'critical'));
+  it('critical level does NOT block skip markers', () => shouldAllow('Edit', {
+    file_path: 'tests/test_auth.py', old_string: 'def test_a():', new_string: '@pytest.mark.skip\ndef test_a():'
+  }, 'critical'));
+  it('strict level blocks a Write of an already-skipped test', () => shouldBlock('Write', {
+    file_path: 'tests/test_new.py', content: '@pytest.mark.skip\ndef test_new():\n    assert True'
+  }, 'write-skipped-test', 'strict'));
+  it('high level does NOT block that Write', () => shouldAllow('Write', {
+    file_path: 'tests/test_new.py', content: '@pytest.mark.skip\ndef test_new():\n    assert True'
+  }, 'high'));
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Integration - real stdin/stdout through the script
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Integration (stdin/stdout)', () => {
+  it('emits a deny decision for test deletion', async () => {
+    const out = await runHook({ tool_name: 'Bash', tool_input: { command: 'rm -rf tests/' } });
+    assert.strictEqual(out.hookSpecificOutput.permissionDecision, 'deny');
+  });
+  it('emits {} for a normal command', async () => {
+    const out = await runHook({ tool_name: 'Bash', tool_input: { command: 'pytest -q' } });
+    assert.deepStrictEqual(out, {});
+  });
+  it('fails open on malformed input', async () => {
+    const out = await runHook({ tool_name: 'Bash' });
+    assert.deepStrictEqual(out, {});
+  });
+});


### PR DESCRIPTION
This implements **`protect-tests`** — one of the hooks listed under *Ideas for new hooks* in the README ("Block test deletion/disabling").

### Why
The most common way an agent produces a false "all green" is not a catastrophic command — it's quietly making the suite pass by **deleting, renaming-away, or disabling** the failing tests instead of fixing the code. `block-dangerous-commands` and `git-safety` don't cover this. This hook does.

### What it blocks
- **Bash** — `rm` / `git rm` / `unlink` / `shred` of test files or test dirs; `mv` of a test file to a disabled name (`.bak`/`.disabled`/`.skip`/…).
- **Edit / MultiEdit** — introducing a skip/xfail/ignore marker into an **existing** test: `@pytest.mark.skip`/`xfail`, `@unittest.skip`, `it.skip`/`xit`/`describe.skip`, Go `t.Skip`, JUnit `@Disabled`/`@Ignore`, Rust `#[ignore]`, NUnit `[Ignore]`.
- **Write** (`strict` level only) — writing a test file that is already fully skipped.

### What it deliberately allows (low false-positive)
- Running tests (`pytest`, `npm test`, `go test ./...`).
- `rm -rf node_modules` / `dist` / `build` / `.pytest_cache`.
- Editing a test body, or refactor-renaming to **another test name**.
- **Removing** a skip marker (re-enabling a test) — the marker check is diff-aware (`new` has it, `old` didn't).

### Conventions
Follows the house pattern: `SAFETY_LEVEL` tiers (`critical`/`high`/`strict`, default `high`), JSONL logging to `~/.claude/hooks-logs/`, exported `checkTool()` for testing, fails open (`{}`) on any error.

### Tests
`hook-scripts/tests/pre-tool-use/protect-tests.test.js` — 31 unit + integration cases, `node --test` green. (The 4 pre-existing failures in `format-code` are unrelated — they need `ruff`/`prettier` installed locally.)

README updated: added the row to the Pre-Tool-Use table and removed `protect-tests` from the roadmap.