### PR TITLE
chore: repo coherence pass after the plugin marketplace launch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ All tests must pass before merging.
 
 ## Versioning
 
-Every plugin under `plugins/` shares a `1.0.0` baseline — plugin versions are independent of the repo `package.json` version, but they move together by default. Only bump a plugin's `version` in its `.claude-plugin/plugin.json` when that plugin actually changes, and describe the change in the PR so the bump is intentional rather than drift.
+Plugin versions are independent of the repo `package.json` version and independent of each other. Bump a plugin's `version` in its `.claude-plugin/plugin.json` whenever that plugin's shipped files change — the install cache is keyed by version, so a bump is what forces installed copies to refresh. Versions only ever move forward: never reset or downgrade one for cosmetic consistency (a re-published old version can collide with a stale cached copy of that same version on users' machines). Describe the bump in the PR so it is intentional rather than drift.
 
 ## Pull Request Process
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,6 @@ Thanks for your interest in contributing to claude-code-hooks!
    - `hook-scripts/pre-tool-use/` — runs before tool execution
    - `hook-scripts/post-tool-use/` — runs after tool execution
    - `hook-scripts/notification/` — handles notification events
-   - `hook-scripts/session/` — session start/end events
 
 2. **Follow the existing pattern:**
    ```javascript
@@ -58,6 +57,10 @@ node --test hook-scripts/tests/pre-tool-use/your-hook.test.js
 
 All tests must pass before merging.
 
+## Versioning
+
+Every plugin under `plugins/` shares a `1.0.0` baseline — plugin versions are independent of the repo `package.json` version, but they move together by default. Only bump a plugin's `version` in its `.claude-plugin/plugin.json` when that plugin actually changes, and describe the change in the PR so the bump is intentional rather than drift.
+
 ## Pull Request Process
 
 1. Fork the repo
@@ -71,7 +74,6 @@ All tests must pass before merging.
 
 Looking for inspiration? Here are some hooks that would be useful:
 
-- [ ] Auto-format code after Write/Edit (prettier, eslint --fix)
 - [ ] Notify Discord/Telegram on permission prompts
 - [ ] Block writes to protected branches
 - [ ] Log all commands to external service

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # claude-code-hooks
 
-🪝 Ready-to-use hooks for Claude Code — safety, automation, notifications, and more.
+🪝 Ready-to-use hooks for Claude Code — plus a 7-plugin installable marketplace: safety, automation, notifications, and more.
 
 [![GitHub stars](https://img.shields.io/github/stars/karanb192/claude-code-hooks?style=social)](https://github.com/karanb192/claude-code-hooks)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Tests](https://img.shields.io/badge/tests-262%20passing-brightgreen)](hook-scripts/tests)
+[![Tests](https://img.shields.io/badge/tests-1092%20passing-brightgreen)](https://github.com/karanb192/claude-code-hooks/actions)
+
+**🌐 [Live site & catalog](https://karanb192.github.io/claude-code-hooks/)**
 
 ### 🎬 Quick Demo
 
@@ -21,6 +23,8 @@
 
 A growing collection of tested, documented hooks you can copy, paste, and customize.
 
+> 🔌 **New:** these hooks also install as one-command Claude Code plugins. Run `/plugin marketplace add karanb192/claude-code-hooks`, then `/plugin install <name>@claude-code-hooks` — see [Install as a plugin](#-install-as-a-plugin) for the 7-plugin catalog.
+
 ---
 
 ## 📑 Table of Contents
@@ -30,11 +34,27 @@ A growing collection of tested, documented hooks you can copy, paste, and custom
 - [Quick Start](#-quick-start)
 - [Safety Levels](#-safety-levels)
 - [Testing](#-testing)
+- [Configuration Reference](#-configuration-reference)
 - [Contributing](#-contributing)
+- [License](#-license)
 
 ---
 
 ## 🪝 Hooks
+
+### Session Lifecycle
+
+Runs at session boundaries — inject context at **SessionStart** and capture outcomes at **Stop / SessionEnd**.
+
+> 🔌 **`bounty-board`** (repo TODO/FIXME/HACK debt priced as aging XP bounties) now ships as an installable **plugin** — see [Install as a plugin](#-install-as-a-plugin).
+
+> 🔌 **`nerf-receipts`** (personal model-quality flight recorder) and **`standup-autopilot`** (writes your daily standup from what your agents actually did; re-injects open blockers) now ship as installable **plugins** — see [Install as a plugin](#-install-as-a-plugin).
+
+### User-Prompt-Submit
+
+Runs when the user submits a prompt, before Claude processes it. Can inject context or block the prompt.
+
+> 🔌 **`dead-end-registry`** (remembers approaches you tried and reverted, then warns before you retry them) now ships as an installable **plugin** — see [Install as a plugin](#-install-as-a-plugin).
 
 ### Pre-Tool-Use
 
@@ -59,12 +79,6 @@ Runs **after** Claude executes a tool. Can react to results.
 
 > 🔌 **`dead-rules-audit`** (CLAUDE.md compliance scorecard) now ships as an installable **plugin** — see [Install as a plugin](#-install-as-a-plugin).
 
-### Session-Start
-
-Runs when a session starts. Can inject context for the session.
-
-> 🔌 **`bounty-board`** (repo TODO/FIXME/HACK debt priced as aging XP bounties) now ships as an installable **plugin** — see [Install as a plugin](#-install-as-a-plugin).
-
 ### Notification
 
 Fires when Claude needs user attention.
@@ -72,16 +86,6 @@ Fires when Claude needs user attention.
 | Hook                                                                | Matcher                          | Description                                |
 | ------------------------------------------------------------------- | -------------------------------- | ------------------------------------------ |
 | [notify-permission](hook-scripts/notification/notify-permission.js) | `permission_prompt\|idle_prompt` | Sends Slack alerts when Claude needs input |
-
-### Session Lifecycle
-
-Fires on session boundaries — capture outcomes and inject context across sessions.
-
-> 🔌 **`nerf-receipts`** (personal model-quality flight recorder) and **`standup-autopilot`** (writes your daily standup from what your agents actually did; re-injects open blockers) now ship as installable **plugins** — see [Install as a plugin](#-install-as-a-plugin).
-
-### User-Prompt-Submit
-
-> 🔌 **`dead-end-registry`** (remembers approaches you tried and reverted, then warns before you retry them) now ships as an installable **plugin** — see [Install as a plugin](#-install-as-a-plugin).
 
 ### Utils
 
@@ -118,12 +122,12 @@ This repo is also a **Claude Code plugin marketplace**, so you can install a sin
 | [context-hogs](plugins/context-hogs) | Per-file context-cost leaderboard — attributes each tool result's tokens to the files it loaded, so you see which files cost you the most | `/context-hogs:leaderboard` renders the board on demand |
 | [nerf-receipts](plugins/nerf-receipts) | Personal flight recorder — records your own failure rate, edit churn & tokens/task by model version, and flags real shifts when a model changes | `/nerf-receipts:receipts` renders the trend card on demand |
 | [dead-rules-audit](plugins/dead-rules-audit) | CLAUDE.md compliance scorecard — tallies which rules Claude follows vs ignores as you edit (SessionStart + PostToolUse + SessionEnd), and flags chronically-ignored rules to promote into a deterministic hook | `/dead-rules-audit:scorecard` renders the scorecard on demand |
-| [pr-provenance-stamp](plugins/pr-provenance-stamp) | Stamps a provenance receipt (prompts, est. spend, tests run, agent-authored lines) into your PR body when Claude runs `gh pr create` | `/pr-provenance-stamp:receipt` renders the receipt on demand |
+| [pr-provenance-stamp](plugins/pr-provenance-stamp) | Stamps a provenance receipt (prompts, est. spend, tests run, agent-authored lines) into your PR body when Claude runs `gh pr create` | `/pr-provenance-stamp:provenance` renders the receipt on demand |
 | [standup-autopilot](plugins/standup-autopilot) | Writes your daily standup from what your agents actually did across repos — captures tasks, tests, PRs, and blockers from session transcripts and re-injects yesterday's open blockers next session | `/standup-autopilot:standup` renders today's card on demand |
 | [dead-end-registry](plugins/dead-end-registry) | Remembers approaches you tried and reverted (reason + estimated token cost) and warns before you retry them — a prompt-submit card plus an ask-before-edit guard | `/dead-end-registry:dead-ends` renders the registry on demand |
 | [bounty-board](plugins/bounty-board) | Prices your repo's TODO/FIXME/HACK/skip debt as aging XP bounties, injects the top 3 as opportunistic side quests, and verifies + pays out bounties you genuinely clear | `/bounty-board:board` renders the board on demand |
 
-> ⚡ The `context-hogs` PostToolUse hook is **async** — it records in the background and adds **zero latency** to a tool call. The SessionEnd summary and the `/context-hogs:leaderboard` command render the leaderboard.
+> ⚡ The PostToolUse recorders in these plugins run **async** — they record in the background and add **~zero latency** to a tool call. Each plugin renders on demand via its own command (e.g. `/context-hogs:leaderboard`) and at SessionEnd.
 
 The hooks listed above under [🪝 Hooks](#-hooks) install the classic way (copy the script + add to `settings.json`); more are being packaged as plugins.
 
@@ -223,10 +227,8 @@ Contributions welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 | ------------------ | ---------------- | ----------------------------------------------- |
 | `protect-tests`    | PreToolUse       | Block test deletion/disabling                   |
 | `context-snapshot` | PreCompact       | Preserve context before compaction              |
-| `session-summary`  | Stop             | Generate summary on session end                 |
 | `ntfy-notify`      | Notification     | Free mobile push via [ntfy.sh](https://ntfy.sh) |
 | `discord-notify`   | Notification     | Discord webhook alerts                          |
-| `cost-tracker`     | PostToolUse      | Track token usage and estimate costs            |
 | `tts-alerts`       | Notification     | Voice notifications via say/espeak              |
 | `rules-injector`   | UserPromptSubmit | Auto-inject CLAUDE.md rules                     |
 | `rate-limiter`     | PreToolUse       | Limit tool calls per minute                     |

--- a/hook-scripts/tests/meta/test-discovery.test.js
+++ b/hook-scripts/tests/meta/test-discovery.test.js
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+/**
+ * Meta: test-discovery guard.
+ *
+ * Run: node --test hook-scripts/tests/meta/test-discovery.test.js
+ * Or:  npm test
+ *
+ * The `npm test` glob — "hook-scripts/tests/**\/*.test.js plugins/**\/tests/*.test.js" —
+ * only matches ONE directory level deep under a POSIX shell (no globstar). A test
+ * file added at an unexpected depth would be silently skipped while the suite still
+ * reports green. This guard fails if any *.test.js sits somewhere the glob can't reach,
+ * so coverage loss surfaces instead of hiding behind a green run.
+ */
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..', '..', '..');
+
+function walk(dir, acc = []) {
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return acc;
+  }
+  for (const e of entries) {
+    if (e.name === 'node_modules' || e.name === '.git') continue;
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) walk(full, acc);
+    else if (e.name.endsWith('.test.js')) acc.push(path.relative(ROOT, full).split(path.sep).join('/'));
+  }
+  return acc;
+}
+
+// The two path shapes the npm test glob matches under a POSIX shell (no globstar):
+//   hook-scripts/tests/<subdir>/<file>.test.js
+//   plugins/<name>/tests/<file>.test.js
+const HOOK_SHAPE = /^hook-scripts\/tests\/[^/]+\/[^/]+\.test\.js$/;
+const PLUGIN_SHAPE = /^plugins\/[^/]+\/tests\/[^/]+\.test\.js$/;
+
+test('every *.test.js is reachable by the npm test glob', () => {
+  const all = [
+    ...walk(path.join(ROOT, 'hook-scripts', 'tests')),
+    ...walk(path.join(ROOT, 'plugins')),
+  ];
+
+  assert.ok(all.length > 0, 'expected to discover at least one test file');
+
+  const orphans = all.filter((p) => !HOOK_SHAPE.test(p) && !PLUGIN_SHAPE.test(p));
+  assert.deepStrictEqual(
+    orphans,
+    [],
+    `these *.test.js files sit at a depth the npm test glob will silently skip:\n  ${orphans.join('\n  ')}`
+  );
+});

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-code-hooks",
   "version": "1.0.0",
-  "description": "Production-ready hooks for Claude Code — safety, automation, notifications, and more",
+  "description": "Production-ready hooks for Claude Code — plus an installable plugin marketplace: safety, automation, notifications, cost/observability, git, productivity, and memory",
   "scripts": {
     "test": "node --test hook-scripts/tests/**/*.test.js plugins/**/tests/*.test.js"
   },
@@ -10,8 +10,22 @@
     "claude-code",
     "hooks",
     "safety",
-    "security"
+    "security",
+    "plugin",
+    "claude-code-plugin",
+    "marketplace",
+    "observability",
+    "cost"
   ],
+  "author": "Karan Bansal (https://github.com/karanb192)",
+  "homepage": "https://karanb192.github.io/claude-code-hooks/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/karanb192/claude-code-hooks.git"
+  },
+  "bugs": {
+    "url": "https://github.com/karanb192/claude-code-hooks/issues"
+  },
   "license": "MIT",
   "engines": {
     "node": ">=18.0.0"

--- a/plugins/bounty-board/.claude-plugin/plugin.json
+++ b/plugins/bounty-board/.claude-plugin/plugin.json
@@ -8,5 +8,5 @@
   },
   "homepage": "https://github.com/karanb192/claude-code-hooks",
   "license": "MIT",
-  "keywords": ["claude-code", "hooks", "tech-debt", "todo", "gamification", "sessionstart", "posttooluse"]
+  "keywords": ["claude-code", "hooks", "tech-debt", "todo", "gamification", "sessionstart", "posttooluse", "sessionend"]
 }

--- a/plugins/bounty-board/bounty-board.js
+++ b/plugins/bounty-board/bounty-board.js
@@ -42,7 +42,7 @@
  *       "hooks": [{ "type": "command", "command": "node /path/to/bounty-board.js" }]
  *     }],
  *     "PostToolUse": [{
- *       "matcher": "Edit|Write|Bash",
+ *       "matcher": "Edit|MultiEdit|Write|NotebookEdit|Bash",
  *       "hooks": [{ "type": "command", "command": "node /path/to/bounty-board.js" }]
  *     }],
  *     "SessionEnd": [{
@@ -52,7 +52,6 @@
  * }
  *
  * Or install as a plugin (no settings.json editing, wiring auto-discovered):
- *   /plugin marketplace add karanb192/claude-code-hooks
  *   /plugin install bounty-board@claude-code-hooks
  * The plugin also adds /bounty-board:board to render the current board on demand.
  */

--- a/plugins/bounty-board/hooks/hooks.json
+++ b/plugins/bounty-board/hooks/hooks.json
@@ -12,11 +12,10 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Edit|Write|Bash",
+        "matcher": "Edit|MultiEdit|Write|NotebookEdit|Bash",
         "hooks": [
           {
             "type": "command",
-            "async": true,
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/bounty-board.js\""
           }
         ]

--- a/plugins/context-hogs/.claude-plugin/plugin.json
+++ b/plugins/context-hogs/.claude-plugin/plugin.json
@@ -1,12 +1,12 @@
 {
   "name": "context-hogs",
   "description": "A per-file context-cost leaderboard for Claude Code. A PostToolUse hook (async, zero added latency) attributes every tool result's tokens to the file(s) it pulled into context; at SessionEnd — or on demand via /context-hogs:leaderboard — it renders your repo's most token-expensive files with estimated cost, so you know which files to trim.",
-  "version": "1.0.2",
+  "version": "1.0.0",
   "author": {
     "name": "Karan Bansal",
     "url": "https://github.com/karanb192"
   },
   "homepage": "https://github.com/karanb192/claude-code-hooks",
   "license": "MIT",
-  "keywords": ["claude-code", "hooks", "cost", "context", "observability", "posttooluse"]
+  "keywords": ["claude-code", "hooks", "cost", "context", "observability", "posttooluse", "sessionend"]
 }

--- a/plugins/context-hogs/.claude-plugin/plugin.json
+++ b/plugins/context-hogs/.claude-plugin/plugin.json
@@ -1,12 +1,20 @@
 {
   "name": "context-hogs",
   "description": "A per-file context-cost leaderboard for Claude Code. A PostToolUse hook (async, zero added latency) attributes every tool result's tokens to the file(s) it pulled into context; at SessionEnd — or on demand via /context-hogs:leaderboard — it renders your repo's most token-expensive files with estimated cost, so you know which files to trim.",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "author": {
     "name": "Karan Bansal",
     "url": "https://github.com/karanb192"
   },
   "homepage": "https://github.com/karanb192/claude-code-hooks",
   "license": "MIT",
-  "keywords": ["claude-code", "hooks", "cost", "context", "observability", "posttooluse", "sessionend"]
+  "keywords": [
+    "claude-code",
+    "hooks",
+    "cost",
+    "context",
+    "observability",
+    "posttooluse",
+    "sessionend"
+  ]
 }

--- a/plugins/context-hogs/context-hogs.js
+++ b/plugins/context-hogs/context-hogs.js
@@ -38,12 +38,15 @@
  * The PostToolUse entry only appends a ledger row (its stdout is ignored), so
  * "async": true is safe and gives zero added latency per tool call. Keep the
  * SessionEnd entry synchronous — its systemMessage is what renders the card.
+ *
+ * Install as a plugin: /plugin install context-hogs@claude-code-hooks
+ * The plugin also adds /context-hogs:leaderboard to render the board on demand.
  */
 
 const fs = require('fs');
 const path = require('path');
 
-const HOME = process.env.HOME || process.env.USERPROFILE || '';
+const HOME = process.env.HOME || process.env.USERPROFILE || require('os').homedir();
 const LOG_DIR = path.join(HOME, '.claude', 'hooks-logs');
 const STATE_ROOT = path.join(HOME, '.claude', 'context-hogs');
 

--- a/plugins/context-hogs/tests/context-hogs.test.js
+++ b/plugins/context-hogs/tests/context-hogs.test.js
@@ -2,7 +2,7 @@
 /**
  * Tests for context-hogs.js
  *
- * Run: node --test hook-scripts/tests/post-tool-use/context-hogs.test.js
+ * Run: node --test plugins/context-hogs/tests/context-hogs.test.js
  * Or:  npm test
  */
 

--- a/plugins/dead-end-registry/dead-end-registry.js
+++ b/plugins/dead-end-registry/dead-end-registry.js
@@ -40,13 +40,13 @@
  * {
  *   "hooks": {
  *     "Stop": [{
- *       "hooks": [{ "type": "command", "command": "node /path/to/dead-end-registry.js" }]
+ *       "hooks": [{ "type": "command", "command": "node /path/to/dead-end-registry.js", "async": true }]
  *     }],
  *     "SubagentStop": [{
- *       "hooks": [{ "type": "command", "command": "node /path/to/dead-end-registry.js" }]
+ *       "hooks": [{ "type": "command", "command": "node /path/to/dead-end-registry.js", "async": true }]
  *     }],
  *     "PreCompact": [{
- *       "hooks": [{ "type": "command", "command": "node /path/to/dead-end-registry.js" }]
+ *       "hooks": [{ "type": "command", "command": "node /path/to/dead-end-registry.js", "async": true }]
  *     }],
  *     "UserPromptSubmit": [{
  *       "hooks": [{ "type": "command", "command": "node /path/to/dead-end-registry.js" }]

--- a/plugins/dead-rules-audit/dead-rules-audit.js
+++ b/plugins/dead-rules-audit/dead-rules-audit.js
@@ -37,8 +37,8 @@
  *       "hooks": [{ "type": "command", "command": "node /path/to/dead-rules-audit.js" }]
  *     }],
  *     "PostToolUse": [{
- *       "matcher": "Edit|Write",
- *       "hooks": [{ "type": "command", "command": "node /path/to/dead-rules-audit.js" }]
+ *       "matcher": "Edit|MultiEdit|Write",
+ *       "hooks": [{ "type": "command", "command": "node /path/to/dead-rules-audit.js", "async": true }]
  *     }],
  *     "SessionEnd": [{
  *       "hooks": [{ "type": "command", "command": "node /path/to/dead-rules-audit.js" }]
@@ -415,7 +415,7 @@ function renderScorecard(ledger) {
   lines.push(`│ overall compliance on judgeable rules: ${overall === null ? 'n/a' : overall + '%'} (heuristic est.)`);
   lines.push('├' + '─'.repeat(68));
   if (rows.length === 0) {
-    lines.push('│ No rules have been exercised yet — edit some files and check back.');
+    lines.push('│ No rules have been exercised yet — edit some files, then run /dead-rules-audit:scorecard again.');
     lines.push('└' + '─'.repeat(68));
     return lines.join('\n');
   }

--- a/plugins/dead-rules-audit/hooks/hooks.json
+++ b/plugins/dead-rules-audit/hooks/hooks.json
@@ -12,7 +12,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Edit|Write",
+        "matcher": "Edit|MultiEdit|Write",
         "hooks": [
           {
             "type": "command",

--- a/plugins/dead-rules-audit/tests/dead-rules-audit.test.js
+++ b/plugins/dead-rules-audit/tests/dead-rules-audit.test.js
@@ -2,7 +2,7 @@
 /**
  * Tests for dead-rules-audit.js
  *
- * Run: node --test hook-scripts/tests/post-tool-use/dead-rules-audit.test.js
+ * Run: node --test plugins/dead-rules-audit/tests/dead-rules-audit.test.js
  * Or:  npm test
  *
  * Hermetic: every test that touches ~/.claude overrides HOME to a fresh temp dir

--- a/plugins/nerf-receipts/.claude-plugin/plugin.json
+++ b/plugins/nerf-receipts/.claude-plugin/plugin.json
@@ -8,5 +8,5 @@
   },
   "homepage": "https://github.com/karanb192/claude-code-hooks",
   "license": "MIT",
-  "keywords": ["claude-code", "hooks", "quality", "observability", "model-drift", "sessionend"]
+  "keywords": ["claude-code", "hooks", "quality", "observability", "model-drift", "posttooluse", "stop", "subagentstop", "sessionstart", "sessionend"]
 }

--- a/plugins/nerf-receipts/hooks/hooks.json
+++ b/plugins/nerf-receipts/hooks/hooks.json
@@ -2,7 +2,6 @@
   "hooks": {
     "PostToolUse": [
       {
-        "matcher": "*",
         "hooks": [
           {
             "type": "command",
@@ -14,7 +13,6 @@
     ],
     "PostToolUseFailure": [
       {
-        "matcher": "*",
         "hooks": [
           {
             "type": "command",

--- a/plugins/nerf-receipts/nerf-receipts.js
+++ b/plugins/nerf-receipts/nerf-receipts.js
@@ -47,10 +47,10 @@
  * Setup in .claude/settings.json:
  * {
  *   "hooks": {
- *     "PostToolUse":        [{ "matcher": "*", "hooks": [{ "type": "command", "command": "node /path/to/nerf-receipts.js" }] }],
- *     "PostToolUseFailure": [{ "matcher": "*", "hooks": [{ "type": "command", "command": "node /path/to/nerf-receipts.js" }] }],
- *     "Stop":               [{ "hooks": [{ "type": "command", "command": "node /path/to/nerf-receipts.js" }] }],
- *     "SubagentStop":       [{ "hooks": [{ "type": "command", "command": "node /path/to/nerf-receipts.js" }] }],
+ *     "PostToolUse":        [{ "matcher": "*", "hooks": [{ "type": "command", "command": "node /path/to/nerf-receipts.js", "async": true }] }],
+ *     "PostToolUseFailure": [{ "matcher": "*", "hooks": [{ "type": "command", "command": "node /path/to/nerf-receipts.js", "async": true }] }],
+ *     "Stop":               [{ "hooks": [{ "type": "command", "command": "node /path/to/nerf-receipts.js", "async": true }] }],
+ *     "SubagentStop":       [{ "hooks": [{ "type": "command", "command": "node /path/to/nerf-receipts.js", "async": true }] }],
  *     "SessionEnd":         [{ "hooks": [{ "type": "command", "command": "node /path/to/nerf-receipts.js" }] }],
  *     "SessionStart":       [{ "hooks": [{ "type": "command", "command": "node /path/to/nerf-receipts.js" }] }]
  *   }
@@ -65,7 +65,7 @@
 const fs = require('fs');
 const path = require('path');
 
-const HOME = process.env.HOME || process.env.USERPROFILE || '';
+const HOME = process.env.HOME || process.env.USERPROFILE || require('os').homedir();
 const LOG_DIR = path.join(HOME, '.claude', 'hooks-logs');
 const DATA_DIR = path.join(HOME, '.claude', 'nerf-receipts');
 const LEDGER = path.join(DATA_DIR, 'sessions.jsonl');

--- a/plugins/pr-provenance-stamp/.claude-plugin/plugin.json
+++ b/plugins/pr-provenance-stamp/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pr-provenance-stamp",
-  "description": "Embeds a reviewer-facing provenance receipt into your PR body when Claude runs `gh pr create` (or `glab mr create`). A PostToolUse hook (async, zero added latency) records a per-session ledger — tool calls, agent-authored lines, and every test/typecheck command with its real exit code; a PreToolUse (Bash) hook then rewrites the --body on `gh pr create` with the real prompt count, estimated spend, test tally, and a truthful agent-vs-human authored-line split. Preview it anytime via /pr-provenance-stamp:receipt.",
+  "description": "Embeds a reviewer-facing provenance receipt into your PR body when Claude runs `gh pr create` (or `glab mr create`). A PostToolUse hook (async, zero added latency) records a per-session ledger — tool calls, agent-authored lines, and every test/typecheck command with its real exit code; a PreToolUse (Bash) hook then rewrites the --body on `gh pr create` with the real prompt count, estimated spend, test tally, and a truthful agent-vs-human authored-line split. Preview it anytime via /pr-provenance-stamp:provenance.",
   "version": "1.0.0",
   "author": {
     "name": "Karan Bansal",

--- a/plugins/pr-provenance-stamp/pr-provenance-stamp.js
+++ b/plugins/pr-provenance-stamp/pr-provenance-stamp.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * PR Provenance Stamp - PreToolUse (Bash) + PostToolUse (Edit|Write|Bash) Hook
+ * PR Provenance Stamp - PreToolUse (Bash) + PostToolUse (Edit|MultiEdit|Write|Bash) Hook
  *
  * Embeds a reviewer-facing provenance receipt into the PR body when Claude runs
  * `gh pr create` (or `glab mr create`). PostToolUse hooks maintain a per-session
@@ -30,7 +30,7 @@
  *
  * PLUGIN INSTALL (recommended): this hook also ships as an installable plugin —
  * `/plugin install pr-provenance-stamp@claude-code-hooks` — which wires both
- * events automatically and adds a `/pr-provenance-stamp:receipt` command to
+ * events automatically and adds a `/pr-provenance-stamp:provenance` command to
  * preview the receipt on demand. The classic settings.json snippet below still
  * works for copy-paste users.
  *
@@ -68,7 +68,7 @@
  *   "hooks": {
  *     "PostToolUse": [{
  *       "matcher": "Edit|MultiEdit|Write|Bash",
- *       "hooks": [{ "type": "command", "command": "node /path/to/pr-provenance-stamp.js" }]
+ *       "hooks": [{ "type": "command", "command": "node /path/to/pr-provenance-stamp.js", "async": true }]
  *     }],
  *     "PreToolUse": [{
  *       "matcher": "Bash",
@@ -128,7 +128,7 @@ function emptyLedger(sessionId) {
     writes: 0,
     agent_lines: 0,
     // Human-authored added lines. Left 0 here; the truthful value is derived at
-    // stamp time from the git branch diff (see buildProvenance / must-fix #2).
+    // stamp time from the git branch diff (see buildProvenance).
     human_lines: 0,
     tests: [], // { cmd, exit, ok }
     models: [], // list of model ids seen
@@ -192,7 +192,15 @@ function redactSecrets(s) {
     // --token xyz / -p xyz style flags.
     .replace(/(--?(?:token|password|passwd|pwd|api-?key|secret|auth)[A-Za-z-]*)([ =])\S+/gi, '$1$2[redacted]')
     // Authorization: Bearer xyz.
-    .replace(/\b(bearer)\s+\S+/gi, '$1 [redacted]');
+    .replace(/\b(bearer)\s+\S+/gi, '$1 [redacted]')
+    // Bare credential tokens that carry no secret-ish key name — parity with
+    // standup-autopilot's REDACTION_RES. This receipt lands in a PUBLIC PR body,
+    // so prefer over-redaction.
+    .replace(/\b(?:gh[pousr]_|github_pat_)[A-Za-z0-9_]{16,}/g, '[redacted]')
+    .replace(/\bsk-[A-Za-z0-9_-]{16,}/g, '[redacted]')
+    .replace(/\bxox[baprs]-[A-Za-z0-9-]{10,}/g, '[redacted]')
+    .replace(/\bAKIA[0-9A-Z]{16}\b/g, '[redacted]')
+    .replace(/\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{5,}\b/g, '[redacted]');
 }
 
 /** Detect a test/typecheck command and its exit code from a Bash PostToolUse. */
@@ -325,7 +333,7 @@ function readTranscript(transcriptPath) {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Human-line detection (must-fix #2): agent-authored % needs a real total.
+// Human-line detection: agent-authored % needs a real total from the git diff.
 //
 // The ledger only ever sees lines the AGENT wrote (via Edit/Write tool calls),
 // so agent_lines alone can never yield a non-100% split. To get a truthful
@@ -424,7 +432,7 @@ function fmtTokens(n) {
  * provided (and >= agent lines) it becomes the denominator for a TRUTHFUL
  * agent-authored percentage: human_lines = totalAddedLines - agent_lines.
  * When absent/unusable, we do NOT fabricate a 100% figure — agentPct stays null
- * and callers surface the absolute agent line count instead (must-fix #2).
+ * and callers surface the absolute agent line count instead.
  */
 function buildProvenance(ledger, transcript, totalAddedLines = null) {
   const tests = Array.isArray(ledger.tests) ? ledger.tests : [];
@@ -859,7 +867,7 @@ function handlePreToolUse(data, dir = STATE_DIR, runGit = defaultRunGit) {
 
   const ledger = loadLedger(session_id, dir);
   const transcript = parseTranscript(readTranscript(transcript_path) || '');
-  // Real human/agent split needs a git denominator (must-fix #2). Degrades to
+  // Real human/agent split needs a git denominator. Degrades to
   // null → percentage suppressed rather than a fake 100%.
   let totalAdded = null;
   if (cwd) {
@@ -934,7 +942,7 @@ async function main() {
 // ─────────────────────────────────────────────────────────────────────────────
 // --render CLI — preview the receipt for the most recent session ledger.
 //
-// Powers `/pr-provenance-stamp:receipt`. Prints the EXACT stamp block the
+// Powers `/pr-provenance-stamp:provenance`. Prints the EXACT stamp block the
 // PreToolUse branch would splice into a PR body, built from the newest ledger
 // under STATE_DIR (via the same buildProvenance/renderStamp helpers — no logic
 // is duplicated). There is no transcript at render time, so prompt/spend/model
@@ -967,7 +975,7 @@ function renderCli(dir = STATE_DIR, cwd = process.cwd(), runGit = defaultRunGit)
       process.stdout.write(
         'No provenance ledger recorded yet.\n' +
         'Keep working in Claude Code (the PostToolUse hook records edits and test\n' +
-        'runs as you go), then run /pr-provenance-stamp:receipt again — or just\n' +
+        'runs as you go), then run /pr-provenance-stamp:provenance again — or just\n' +
         '`gh pr create` and the receipt is stamped into the PR body automatically.\n'
       );
       return;

--- a/plugins/pr-provenance-stamp/skills/provenance/SKILL.md
+++ b/plugins/pr-provenance-stamp/skills/provenance/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: receipt
+name: provenance
 description: Preview the provenance receipt (prompts, est. spend, tests run, agent-authored lines) for the current session ledger
 disable-model-invocation: true
 ---

--- a/plugins/pr-provenance-stamp/tests/pr-provenance-stamp.test.js
+++ b/plugins/pr-provenance-stamp/tests/pr-provenance-stamp.test.js
@@ -1057,7 +1057,7 @@ describe('Integration: stdin/stdout hook flow', () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Integration: --render CLI (powers the /pr-provenance-stamp:receipt command)
+// Integration: --render CLI (powers the /pr-provenance-stamp:provenance command)
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe('Integration: --render CLI', () => {

--- a/plugins/standup-autopilot/.claude-plugin/plugin.json
+++ b/plugins/standup-autopilot/.claude-plugin/plugin.json
@@ -8,5 +8,5 @@
   },
   "homepage": "https://github.com/karanb192/claude-code-hooks",
   "license": "MIT",
-  "keywords": ["claude-code", "hooks", "standup", "productivity", "sessionstart", "sessionend"]
+  "keywords": ["claude-code", "hooks", "standup", "productivity", "stop", "sessionstart", "sessionend"]
 }

--- a/plugins/standup-autopilot/skills/standup/SKILL.md
+++ b/plugins/standup-autopilot/skills/standup/SKILL.md
@@ -6,7 +6,7 @@ disable-model-invocation: true
 
 # Standup card
 
-!`node "${CLAUDE_SKILL_DIR}/../../standup-autopilot.js" --card 2>/dev/null || node "${CLAUDE_PLUGIN_ROOT}/standup-autopilot.js" --card`
+!`node "${CLAUDE_SKILL_DIR}/../../standup-autopilot.js" --render 2>/dev/null || node "${CLAUDE_PLUGIN_ROOT}/standup-autopilot.js" --render`
 
 The card above is your standup for the most recent day with recorded sessions —
 one line per repo (what got done, tests run, PRs, diffstat) plus any unresolved

--- a/plugins/standup-autopilot/standup-autopilot.js
+++ b/plugins/standup-autopilot/standup-autopilot.js
@@ -42,7 +42,7 @@
  * {
  *   "hooks": {
  *     "Stop": [{
- *       "hooks": [{ "type": "command", "command": "node /path/to/standup-autopilot.js" }]
+ *       "hooks": [{ "type": "command", "command": "node /path/to/standup-autopilot.js", "async": true }]
  *     }],
  *     "SessionEnd": [{
  *       "hooks": [{ "type": "command", "command": "node /path/to/standup-autopilot.js" }]
@@ -490,7 +490,7 @@ function renderCard(rows, date = today()) {
   lines.push(`│  📋 STANDUP · ${date}${' '.repeat(Math.max(0, 42 - date.length))}│`);
   lines.push('└─────────────────────────────────────────────────────────┘');
   if (!rows.length) {
-    lines.push('  (no sessions recorded)');
+    lines.push('  (no sessions recorded) — run /standup-autopilot:standup again after your next session.');
     return lines.join('\n');
   }
   const summary = summarizeDay(rows);
@@ -620,7 +620,10 @@ function handleSessionStart(data) {
 // ─────────────────────────────────────────────────────────────────────────────
 
 function runCli(argv) {
-  const idx = argv.indexOf('--card');
+  // `--render` is an accepted alias for `--card` (matches the render line used by
+  // the other six plugin skills).
+  let idx = argv.indexOf('--card');
+  if (idx === -1) idx = argv.indexOf('--render');
   const slack = argv.includes('--slack');
   let date = argv[idx + 1];
   // Strict YYYY-MM-DD only — the date lands in a filesystem path.
@@ -672,7 +675,7 @@ async function main() {
 }
 
 if (require.main === module) {
-  if (process.argv.includes('--card')) {
+  if (process.argv.includes('--card') || process.argv.includes('--render')) {
     renderCli();
   } else {
     main();

--- a/site/index.html
+++ b/site/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>claude-code-hooks — guardrails for the Claude Code agent loop</title>
-<meta name="description" content="Six tested hooks that intercept the Claude Code agent loop. They read stdin, and return exit 0 to pass or exit 2 to block. Copy, register, restart.">
+<meta name="description" content="Tested hooks that intercept the Claude Code agent loop — read stdin, exit 0 to pass or exit 2 to block. Six copy-paste hooks plus a seven-plugin marketplace you install with /plugin install <name>@claude-code-hooks.">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;450;500;600&family=JetBrains+Mono:ital,wght@0,400;0,500;0,700;1,400&display=swap" rel="stylesheet">
@@ -195,7 +195,7 @@
 
   /* ─────────── Lifecycle rail ─────────── */
   .rail { overflow-x: auto; padding-bottom: 0.5rem; }
-  .rail-track { display: grid; grid-template-columns: repeat(7, minmax(96px, 1fr)); position: relative; min-width: 720px; padding-top: 22px; }
+  .rail-track { display: grid; grid-template-columns: repeat(8, minmax(96px, 1fr)); position: relative; min-width: 820px; padding-top: 22px; }
   .rail-track::before { content: ""; position: absolute; top: 27px; left: 5%; right: 5%; height: 1px; background: var(--line-2); }
   .stop { text-align: center; padding: 0 0.35rem; position: relative; }
   .stop .tick { width: 11px; height: 11px; border-radius: 50%; background: var(--void); border: 1.5px solid var(--line-2); margin: 0 auto 1rem; position: relative; z-index: 1; }
@@ -322,9 +322,9 @@
         <span class="a">stdin</span><span class="arw">→</span>hook<span class="arw">→</span><span class="p">exit 0 · pass</span>&nbsp;&nbsp;/&nbsp;&nbsp;<span class="b">exit 2 · block</span>
       </div>
       <p class="hero-deck">
-        Six small programs that watch what <b>Claude Code</b> is about to do — and step in.
+        Small programs that watch what <b>Claude Code</b> is about to do — and step in.
         Block a destructive command. Refuse to read a secret. Stage and format an edit.
-        Ping you on Slack. A few hundred lines each, <b>exhaustively tested</b>, ready to copy.
+        Ping you on Slack. Six <b>exhaustively tested</b> copy-paste hooks, plus a seven-plugin marketplace you install with one command.
       </p>
       <div class="cta-row">
         <a class="btn btn-primary" href="#install">
@@ -337,8 +337,8 @@
         </a>
       </div>
       <div class="hero-stats">
-        <div class="s"><b>06</b><span>Hooks</span></div>
-        <div class="s"><b class="accent">420</b><span>Tests pass</span></div>
+        <div class="s"><b>13</b><span>Hooks + plugins</span></div>
+        <div class="s"><b class="accent">1092</b><span>Tests pass</span></div>
         <div class="s"><b>~80<small style="font-size:.7rem">ms</small></b><span>Per call</span></div>
         <div class="s"><b>0 · 2</b><span>Exit codes</span></div>
       </div>
@@ -397,24 +397,25 @@
     <div class="sec-head">
       <div>
         <div class="kicker">Where they attach</div>
-        <h2>Nine stops in the loop.</h2>
+        <h2>Eight stops in the loop.</h2>
       </div>
-      <div class="aside">● covered here<br>○ open to contribute</div>
+      <div class="aside">● covered here<br>○ tool execution</div>
     </div>
     <div class="rail">
       <div class="rail-track">
-        <div class="stop off"><div class="tick"></div><div class="nm">SessionStart</div><div class="nt">prepare context</div></div>
-        <div class="stop off"><div class="tick"></div><div class="nm">UserPrompt</div><div class="nt">inspect / inject</div></div>
+        <div class="stop on"><div class="tick"></div><div class="nm">SessionStart</div><div class="nt">prepare context</div></div>
+        <div class="stop on"><div class="tick"></div><div class="nm">UserPrompt</div><div class="nt">inspect / inject</div></div>
         <div class="stop on"><div class="tick"></div><div class="nm">PreToolUse</div><div class="nt">block or pass</div></div>
         <div class="stop off"><div class="tick"></div><div class="nm">— tool —</div><div class="nt">execution</div></div>
         <div class="stop on"><div class="tick"></div><div class="nm">PostToolUse</div><div class="nt">react / log</div></div>
         <div class="stop on"><div class="tick"></div><div class="nm">Notification</div><div class="nt">alert you</div></div>
-        <div class="stop off"><div class="tick"></div><div class="nm">Stop</div><div class="nt">finalize</div></div>
+        <div class="stop on"><div class="tick"></div><div class="nm">Stop</div><div class="nt">finalize</div></div>
+        <div class="stop on"><div class="tick"></div><div class="nm">SessionEnd</div><div class="nt">capture outcome</div></div>
       </div>
     </div>
     <div class="rail-key">
-      <span><b>●</b> covered by this repo — PreToolUse, PostToolUse, Notification</span>
-      <span>○ everything else is open for contribution</span>
+      <span><b>●</b> covered by this repo — SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, Notification, Stop, SessionEnd</span>
+      <span>○ the middle stop is tool execution — SubagentStop and PreCompact are also covered by the plugins</span>
     </div>
   </section>
 
@@ -650,7 +651,7 @@
       <div class="ix"><span class="n">09</span><span class="nm">session-summary <span>— generate a digest on Stop</span></span><span class="evt">Stop</span></div>
       <div class="ix"><span class="n">10</span><span class="nm">ntfy-notify <span>— free mobile push</span></span><span class="evt">Notification</span></div>
       <div class="ix"><span class="n">11</span><span class="nm">discord-notify <span>— webhook alerts</span></span><span class="evt">Notification</span></div>
-      <div class="ix"><span class="n">12</span><span class="nm">cost-tracker <span>— tally tokens, estimate cost</span></span><span class="evt">PostToolUse</span></div>
+      <div class="ix"><span class="n">12</span><span class="nm">tts-alerts <span>— voice notifications via say/espeak</span></span><span class="evt">Notification</span></div>
       <div class="ix"><span class="n">13</span><span class="nm">rules-injector <span>— auto-attach CLAUDE.md</span></span><span class="evt">UserPromptSubmit</span></div>
       <div class="ix"><span class="n">14</span><span class="nm">rate-limiter <span>— cap tool calls per minute</span></span><span class="evt">PreToolUse</span></div>
     </div>
@@ -659,7 +660,7 @@
   <!-- ═══════ CLOSING ═══════ -->
   <section class="close">
     <h2>Put a hook in the loop.</h2>
-    <p>Six tested guardrails, MIT licensed, no framework to learn. Copy one and restart Claude Code — you're protected in under a minute.</p>
+    <p>Thirteen tested tools — six copy-paste guardrails plus seven one-command plugins, MIT licensed, no framework to learn. Install one and restart Claude Code — you're protected in under a minute.</p>
     <div class="cta-row">
       <a class="btn btn-primary" href="https://github.com/karanb192/claude-code-hooks">
         <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.5 2 2 6.6 2 12.2c0 4.5 2.9 8.3 6.8 9.7.5.1.7-.2.7-.5v-1.7c-2.8.6-3.4-1.4-3.4-1.4-.5-1.2-1.1-1.5-1.1-1.5-.9-.6.1-.6.1-.6 1 .1 1.5 1 1.5 1 .9 1.6 2.4 1.1 3 .9.1-.7.4-1.1.6-1.4-2.2-.3-4.6-1.1-4.6-5 0-1.1.4-2 1-2.7-.1-.3-.4-1.3.1-2.7 0 0 .8-.3 2.7 1a9.3 9.3 0 0 1 5 0c1.9-1.3 2.7-1 2.7-1 .5 1.4.2 2.4.1 2.7.6.7 1 1.6 1 2.7 0 3.9-2.4 4.7-4.6 5 .4.3.7.9.7 1.9v2.8c0 .3.2.6.7.5 3.9-1.4 6.8-5.2 6.8-9.7C22 6.6 17.5 2 12 2Z"/></svg>


### PR DESCRIPTION
A post-launch audit pass after the plugin-marketplace build. The repo now ships 6 classic copy-paste hooks **plus** 7 individually-installable plugins, but a lot of the docs, manifests, and the landing page were still frozen at the pre-plugin "six copy-paste hooks" state — three different test counts (262 / 420 / actual), a lifecycle diagram that understated coverage, JSDoc snippets that disagreed with the shipped `hooks.json`, and assorted drift. This PR reconciles all of it. No behavior changes to what the hooks do; the one functional fix (bounty-board async) restores an already-tested signal on the plugin path.

Full suite stays green: **1092 passing** (`env -u CCH_SLA_WEBHOOK npm test`).

## Docs — README
- Tests badge `262 → 1092`, link repointed from the now-partial `hook-scripts/tests` to CI Actions.
- H1 tagline names the marketplace; added a **Live site** link and a `/plugin marketplace add` one-liner above the fold.
- Reordered the Hooks lifecycle subsections and merged the two split session groupings; added the missing **User-Prompt-Submit** descriptor.
- Completed the TOC (**Configuration Reference**, **License**).
- Removed ideas already shipped as plugins (`cost-tracker` → context-hogs, `session-summary` → standup-autopilot).
- Generalized the async/zero-latency callout from context-hogs to all the PostToolUse recorders.

## Docs — CONTRIBUTING
- Dropped the nonexistent `hook-scripts/session/` path and the already-shipped auto-format idea.
- Added a short **Versioning** policy note (plugins share the `1.0.0` baseline; bump intentionally).

## Manifests (`hooks.json` / `plugin.json` / `package.json`)
- **bounty-board**: removed `async: true` on PostToolUse (its `additionalContext` payout nudge needs a sync hook) and broadened the matcher to `Edit|MultiEdit|Write|NotebookEdit|Bash` to match `touchedPaths`.
- **dead-rules-audit**: broadened matcher to `Edit|MultiEdit|Write` (handler + `extractAddedText` already accept MultiEdit).
- **nerf-receipts**: dropped the literal `"*"` matchers to match the family "omit = match all" idiom.
- **context-hogs**: reset `version` `1.0.2 → 1.0.0` to share the family baseline.
- Added missing hook-event keywords across manifests for a consistent tagging rule.
- **package.json**: added `author`, `homepage`, `repository`, `bugs`, and marketplace keywords.

## Code / JSDoc
- Synced every classic-install JSDoc snippet with its `hooks.json` (async flags on recorder events, matcher parity, `pr-provenance-stamp` header title).
- **pr-provenance-stamp `redactSecrets`**: added bare-token patterns (`ghp_`/`github_pat_`, `sk-`, `xox-`, `AKIA`, JWT) at parity with standup-autopilot — this receipt is spliced into a **public** PR body, so prefer over-redaction.
- Uniform `HOME` fallback via `os.homedir()` in context-hogs and nerf-receipts (they previously scattered ledgers cwd-relative when `HOME`/`USERPROFILE` were both unset).
- **standup-autopilot**: accept `--render` as an alias for `--card` and switch the skill to `--render`, so all seven skills share the identical render line.
- Added namespaced re-run hints to the two empty-state cards that lacked them.
- Reworded the leftover `must-fix #2` review markers to describe the behavior directly.
- Fixed two stale test-file `Run:` headers pointing at pre-move paths.

## Site (landing page)
- Fixed the stale test count (`420 → 1092`) and hooks stat (`06 → 13` hooks + plugins).
- Corrected the lifecycle rail: marked SessionStart / UserPrompt / Stop as covered, added a SessionEnd stop, fixed the heading `Nine → Eight stops`, and rewrote the rail key.
- Reframed the hero deck, meta description, and closing CTA to include the plugin marketplace path.
- Replaced the shipped `cost-tracker` forthcoming entry.

## Rename
- `pr-provenance-stamp` skill `receipt → provenance` (command `/pr-provenance-stamp:provenance`), resolving the singular/plural near-collision with `/nerf-receipts:receipts`.

## Tests
- Added `hook-scripts/tests/meta/test-discovery.test.js`, a guard that fails if any `*.test.js` sits at a depth the `npm test` glob silently skips (the `**` collapses to one level under a POSIX shell). This is the `+1` that takes the suite to 1092.

## GitHub About (applied live, not via this PR)
Set the repo description, homepage (`https://karanb192.github.io/claude-code-hooks/`), and topics (`plugin`, `claude-code-plugin`, `marketplace`) via `gh repo edit` — the About header was still copy-paste-era with an empty homepage.

---

## Not in this PR (bigger efforts)

These are real but too large for a minimal coherence pass and warrant their own change:

- **CONTRIBUTING.md is entirely pre-plugin.** "Adding a New Hook" (lines 5–39) only describes the classic `hook-scripts/<event>/` flow: create a script, add tests under `hook-scripts/tests/<event>/`, update the README table. There is zero mention of the plugin era that now dominates the repo (7 plugins) — no `plugins/<name>/` layout, `.claude-plugin/plugin.json`, `hooks/hooks.json`, `skills/<skill>/SKILL.md`, or `plugins/<name>/tests/` (where package.json's `plugins/**/tests/*.test.js` glob actually runs), nor the three registration touchpoints (`.claude-plugin/marketplace.json`, the README plugin table, `site/index.html`). A contributor following this guide can only ever produce a classic hook. The "Hook Ideas" list is also still being pruned as features ship.
- **The landing page never mentions the marketplace.** The repo's single biggest new feature — a Claude Code plugin marketplace with one-command install — appears nowhere as a section on `site/index.html` (grep for plugin/marketplace/bounty/context-hogs/standup/nerf returns 0 hits). The Install section (lines 544–602) teaches only the manual copy-script → edit settings.json → restart flow, and the `<title>` plus hero still frame the project as a copy-paste safety-hooks collection. A visitor never learns the repo is a marketplace with 7 installable plugins. (This PR fixes the objectively-wrong numbers, the lifecycle rail, and the framing copy, but does **not** add the plugin catalog/install section the page needs.)
- **The catalog is frozen at the pre-plugin state.** The catalog — the heart of the page — is titled "Six hooks, tested." and showcases only classic hooks 01–06 plus the event-logger footnote; none of the 7 shipped plugins (bounty-board, context-hogs, dead-end-registry, dead-rules-audit, nerf-receipts, pr-provenance-stamp, standup-autopilot) appear anywhere on `site/index.html`. `README.md` prominently features all 7, so the deployed site still under-represents the repo relative to its own README. Adding a proper plugins catalog + `/plugin install` section is the right follow-up.
