### PR TITLE
docs+site: plugin-era CONTRIBUTING guide + landing-page marketplace section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,40 +2,197 @@
 
 Thanks for your interest in contributing to claude-code-hooks!
 
-## Adding a New Hook
+There are **two ways** to contribute, and they ship differently:
 
-1. **Create the hook script** in the appropriate directory:
+1. **Adding a classic hook** — a single copy-paste script under `hook-scripts/`, wired
+   into `settings.json` by the user. Best for small, self-contained guardrails.
+2. **Adding a plugin** — an installable bundle under `plugins/<name>/` that the user
+   gets with one `/plugin install` command (hooks + a skill + tests, no manual
+   `settings.json` editing). This is where most new work goes.
+
+Pick the path that fits, then follow the matching section below.
+
+---
+
+## Path 1 — Adding a classic hook
+
+1. **Create the hook script** in the matching directory:
    - `hook-scripts/pre-tool-use/` — runs before tool execution
    - `hook-scripts/post-tool-use/` — runs after tool execution
    - `hook-scripts/notification/` — handles notification events
 
-2. **Follow the existing pattern:**
+2. **Follow the existing pattern** — a shebang, a header comment with the
+   `settings.json` snippet, and the `require.main` guard so the file is both an
+   executable hook and a testable module:
+
    ```javascript
    #!/usr/bin/env node
    /**
-    * Hook Name - Event Hook for Matcher
-    * Brief description.
-    * Logs to: ~/.claude/hooks-logs/
-    *
-    * Setup in .claude/settings.json:
-    * { ... }
+    * Hook Name - Event Hook for Matcher. Logs to: ~/.claude/hooks-logs/
+    * Setup in .claude/settings.json: { ... }
     */
-
    // Implementation
 
-   if (require.main === module) {
-     main();
-   } else {
-     module.exports = { /* exported functions for testing */ };
-   }
+   if (require.main === module) main();
+   else module.exports = { /* exported functions for testing */ };
    ```
 
 3. **Add tests** in `hook-scripts/tests/<event-type>/<hook-name>.test.js`:
    - Unit tests for exported functions
-   - Integration tests for stdin/stdout flow
+   - Integration tests for the stdin/stdout flow
    - Config validation tests
 
-4. **Update README.md** with your hook in the appropriate table.
+4. **Update README.md** — add your hook to the appropriate table under
+   [🪝 Hooks](README.md).
+
+---
+
+## Path 2 — Adding a plugin
+
+A plugin is a self-contained directory the marketplace installs on its own. Copy the
+shape of an existing one — [`plugins/context-hogs/`](plugins/context-hogs) and
+[`plugins/pr-provenance-stamp/`](plugins/pr-provenance-stamp) are the clearest
+references — and swap the `<name>`.
+
+### Layout
+
+```
+plugins/<name>/
+├── <name>.js                       # the hook script — lives at the plugin root
+├── .claude-plugin/
+│   └── plugin.json                 # metadata ONLY (see below)
+├── hooks/
+│   └── hooks.json                  # event → command wiring
+├── skills/
+│   └── <skill>/
+│       └── SKILL.md                # the /<name>:<skill> command
+└── tests/
+    └── <name>.test.js              # hermetic tests
+```
+
+### `plugin.json` is metadata-only
+
+It carries **only** these keys: `name`, `description`, `version`, `author`
+(`{ name, url }`), `homepage`, `license`, `keywords`. Nothing else.
+
+> ⚠️ **Do NOT** add `hooks`, `skills`, or `commands` keys here. Hooks are
+> auto-discovered from `hooks/hooks.json` and skills from `skills/`. Declaring them
+> in `plugin.json` double-registers them and breaks loading with
+> **"Duplicate hooks file detected"**.
+
+### `hooks/hooks.json` conventions
+
+Wire each event to the script by its plugin-root path — always
+`node "${CLAUDE_PLUGIN_ROOT}/<name>.js"`. Example (`context-hogs`):
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      { "matcher": "Read|Grep|Glob|Bash", "hooks": [
+        { "type": "command", "async": true, "command": "node \"${CLAUDE_PLUGIN_ROOT}/<name>.js\"" }] }],
+    "SessionEnd": [
+      { "hooks": [
+        { "type": "command", "command": "node \"${CLAUDE_PLUGIN_ROOT}/<name>.js\"" }] }]
+  }
+}
+```
+
+**The `async` rule** — `"async": true` is for **pure recorder events only** (they
+append to a ledger and their stdout is ignored, so they add ~zero latency). Any event
+whose output Claude Code actually consumes **MUST stay synchronous**:
+
+- injects `additionalContext` — `dead-end-registry` `UserPromptSubmit`,
+  `standup-autopilot` `SessionStart`
+- returns a `permissionDecision` — `dead-end-registry` `PreToolUse`
+- rewrites `updatedInput` — `pr-provenance-stamp` `PreToolUse`
+- renders a `systemMessage` card — `context-hogs` `SessionEnd`
+
+Mark one of those `async` and its output is dropped — the feature silently no-ops.
+
+### The skill
+
+Each plugin ships one skill that renders its card on demand. `skills/<skill>/SKILL.md`:
+
+```markdown
+---
+name: <skill>
+description: One line describing what the card shows
+disable-model-invocation: true
+---
+
+# Title
+
+!`node "${CLAUDE_SKILL_DIR}/../../<name>.js" --render 2>/dev/null || node "${CLAUDE_PLUGIN_ROOT}/<name>.js" --render`
+
+Prose telling Claude how to summarize the rendered card. Keep it short; do not re-run
+any commands.
+```
+
+- Frontmatter `name` **must match the folder name**; `disable-model-invocation: true`
+  keeps it an explicit slash command, not something the model fires on its own.
+- The `!`…`` line shells out to your script's `--render` mode — `${CLAUDE_SKILL_DIR}/../../`
+  (two levels up to the plugin root) primary, `${CLAUDE_PLUGIN_ROOT}` fallback.
+- It is invoked as **`/<name>:<skill>`** — e.g. `/context-hogs:leaderboard`.
+
+### The hook-script contract
+
+`<name>.js` is both the hook and its own render CLI. It must:
+
+- Read the event JSON from **stdin**, `JSON.parse` it, and branch on
+  `data.hook_event_name`.
+- **Never crash the agent loop**: on any error (bad JSON included) print `{}` and
+  `exit 0`. Wrap `main()` in try/catch.
+- Keep the `require.main === module` guard and `module.exports` your **pure
+  functions** so tests can import them without spawning.
+- Implement a **`--render`** branch (`process.argv.includes('--render')`) that prints
+  the card to stdout — this is what the skill calls.
+- Log meaningful events to **`~/.claude/hooks-logs/<date>.jsonl`**; keep durable
+  per-plugin state under **`~/.claude/<name>/`**.
+
+### Tests
+
+Put them in **`plugins/<name>/tests/<name>.test.js`** and keep them **hermetic** —
+spawn the script with a fresh temp `HOME` (`fs.mkdtempSync(...)` + `HOME`/`USERPROFILE`
+in `env`) so a run never touches the real home dir or leaks ambient state.
+
+The `npm test` glob (`plugins/**/tests/*.test.js`) picks the file up automatically —
+**as long as it sits exactly one level under `plugins/<name>/tests/`**. The meta guard
+[`hook-scripts/tests/meta/test-discovery.test.js`](hook-scripts/tests/meta/test-discovery.test.js)
+fails the suite if any `*.test.js` lands at a depth the glob can't reach, so coverage
+loss surfaces instead of hiding behind a green run.
+
+### Register the plugin
+
+A plugin isn't discoverable until it's listed. Add it in all of:
+
+1. **`.claude-plugin/marketplace.json`** — a new entry in `plugins[]` with `name`,
+   `source` (`"./plugins/<name>"`), `description`, `category`, and `tags`.
+2. **README.md** — a row in the plugin table under
+   [🔌 Install as a plugin](README.md), with the `/<name>:<skill>` command.
+3. **`site/index.html`** — add a card in the marketplace section and keep the
+   plugin/tool **counts** in the surrounding copy accurate.
+
+### Validate before you PR
+
+Run these from the repo root (`<name>` = your plugin):
+
+```bash
+# 1. Everything parses (JS + the three JSON files)
+node --check plugins/<name>/<name>.js
+node -e "['plugins/<name>/.claude-plugin/plugin.json','plugins/<name>/hooks/hooks.json','.claude-plugin/marketplace.json'].forEach(f=>JSON.parse(require('fs').readFileSync(f)))"
+
+# 2. The marketplace agrees the plugin is well-formed
+claude plugin validate ./plugins/<name>
+
+# 3. Garbage stdin must degrade to `{}` and exit 0 (never crash the loop)
+echo 'not json {{{' | node plugins/<name>/<name>.js   # → {}
+
+# 4. Full suite green
+env -u CCH_SLA_WEBHOOK npm test
+```
+
+---
 
 ## Code Style
 
@@ -48,14 +205,9 @@ Thanks for your interest in contributing to claude-code-hooks!
 ## Testing
 
 ```bash
-# Run all tests
-npm test
-
-# Run specific test file
-node --test hook-scripts/tests/pre-tool-use/your-hook.test.js
+env -u CCH_SLA_WEBHOOK npm test              # whole suite (must be green before merging)
+node --test plugins/<name>/tests/<name>.test.js   # a single plugin's file
 ```
-
-All tests must pass before merging.
 
 ## Versioning
 
@@ -64,22 +216,25 @@ Plugin versions are independent of the repo `package.json` version and independe
 ## Pull Request Process
 
 1. Fork the repo
-2. Create a feature branch (`git checkout -b feat/my-hook`)
-3. Add your hook + tests
-4. Run `npm test` to ensure all tests pass
-5. Update README.md
-6. Submit PR with a clear description
+2. Create a feature branch (`git checkout -b feat/my-hook` or `feat/my-plugin`)
+3. Add your work + tests:
+   - **classic hook** — script under `hook-scripts/` + tests + README table row
+   - **plugin** — the `plugins/<name>/` bundle + tests + all three registration
+     touchpoints, plus a `version` bump if you touch an existing plugin
+4. Run `env -u CCH_SLA_WEBHOOK npm test` to ensure all tests pass
+5. Submit a PR with a clear description (call out any plugin `version` bump)
 
-## Hook Ideas
+## Hook & plugin ideas
 
-Looking for inspiration? Here are some hooks that would be useful:
+Looking for inspiration? These aren't covered yet:
 
 - [ ] Notify Discord/Telegram on permission prompts
-- [ ] Block writes to protected branches
-- [ ] Log all commands to external service
+- [ ] Protected-branch guarding beyond `git-safety.js` — it already denies git ops on
+      the hardcoded `main`/`master`, so the open work is a *configurable* branch list or
+      catching *non-git* writes (editor Edit/Write, `>` redirects) on a protected branch
+- [ ] Log all commands to an external service
 - [ ] Rate limit tool calls
-- [ ] Add context injection on SessionStart
 
 ## Questions?
 
-Open an issue if you have questions or want to discuss a hook idea before implementing.
+Open an issue if you have questions or want to discuss an idea before implementing.

--- a/site/index.html
+++ b/site/index.html
@@ -219,6 +219,20 @@
   .entry p em { color: var(--text); font-style: normal; font-family: var(--mono); font-size: 0.92em; }
   .entry.rev { direction: rtl; } .entry.rev > * { direction: ltr; }
 
+  /* ─────────── Marketplace ─────────── */
+  .mkt-flow { margin-bottom: 2.6rem; }
+  .mkt-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1.2rem; }
+  .pcard { border: 1px solid var(--line); border-radius: 10px; padding: 1.4rem 1.4rem 1.3rem; background: var(--panel); display: flex; flex-direction: column; gap: 0.8rem; transition: border-color 0.2s, background 0.2s; }
+  .pcard:hover { border-color: var(--line-2); background: var(--panel-2); }
+  .pcard h3 { font-family: var(--mono); font-weight: 700; font-size: 1.02rem; letter-spacing: -0.01em; color: var(--text); }
+  .pcard h3 .no { color: var(--faint); font-weight: 400; margin-right: 0.5rem; }
+  .pcard p { color: var(--dim); font-size: 0.9rem; line-height: 1.55; }
+  .pcard .cmd { align-self: flex-start; font-family: var(--mono); font-size: 0.72rem; letter-spacing: 0.01em; padding: 0.3rem 0.6rem; border-radius: 6px; border: 1px solid var(--pass-dim); background: rgba(63,185,80,0.07); color: var(--pass); }
+  .pcard .events { display: flex; flex-wrap: wrap; gap: 0.4rem; margin-top: auto; padding-top: 0.2rem; }
+  .pcard .events .tag { font-size: 0.62rem; padding: 0.18rem 0.45rem; }
+  .mkt-note { font-family: var(--mono); font-size: 0.8rem; color: var(--faint); margin-top: 2rem; padding-top: 1.5rem; border-top: 1px solid var(--line); line-height: 1.7; }
+  .mkt-note b { color: var(--dim); font-weight: 500; }
+
   /* ─────────── Install ─────────── */
   .steps { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1.2rem; }
   .step { border: 1px solid var(--line); border-radius: 10px; background: var(--panel); overflow: hidden; display: flex; flex-direction: column; }
@@ -280,7 +294,7 @@
   @media (max-width: 900px) {
     .hero { grid-template-columns: 1fr; }
     .hero-term { order: 2; }
-    .proto-grid, .steps, .specs { grid-template-columns: 1fr; }
+    .proto-grid, .steps, .specs, .mkt-grid { grid-template-columns: 1fr; }
     .entry, .entry.rev { grid-template-columns: 1fr; direction: ltr; }
     .index { grid-template-columns: 1fr; }
     .nav-links .hide-sm { display: none; }
@@ -304,6 +318,7 @@
     <div class="brand"><span class="blip"></span>claude-code-hooks</div>
     <div class="nav-links">
       <a href="#catalog" class="hide-sm">Hooks</a>
+      <a href="#marketplace" class="hide-sm">Plugins</a>
       <a href="#install" class="hide-sm">Install</a>
       <a href="#protocol" class="hide-sm">Protocol</a>
       <a class="nav-cta" href="https://github.com/karanb192/claude-code-hooks">GitHub ↗</a>
@@ -424,7 +439,8 @@
     <div class="sec-head">
       <div>
         <div class="kicker">The catalog</div>
-        <h2>Six hooks, tested.</h2>
+        <h2>The copy-paste six.</h2>
+        <p style="font-family:var(--mono);font-size:.76rem;color:var(--faint);margin-top:.7rem">Want one-command installs instead? <a href="#marketplace" style="color:var(--pass);border-bottom:1px solid var(--pass-dim)">Seven plugins ↓</a></p>
       </div>
       <div class="aside">node + python<br>MIT licensed</div>
     </div>
@@ -542,12 +558,95 @@
     </p>
   </section>
 
+  <!-- ═══════ MARKETPLACE ═══════ -->
+  <section class="section" id="marketplace">
+    <div class="sec-head">
+      <div>
+        <div class="kicker">The marketplace</div>
+        <h2>Seven plugins. One command each.</h2>
+      </div>
+      <div class="aside">node · MIT<br>/plugin install</div>
+    </div>
+
+    <div class="term mkt-flow obs">
+      <div class="term-bar">
+        <div class="term-dots"><i></i><i></i><i></i></div>
+        <div class="term-title">~/repo — claude</div>
+      </div>
+      <div class="term-body">
+        <span class="l comment"># 1 · add the marketplace, once</span>
+        <span class="l prompt">/plugin marketplace add karanb192/claude-code-hooks</span>
+        <span class="l comment"># 2 · install any of the seven by name</span>
+        <span class="l prompt">/plugin install context-hogs@claude-code-hooks</span>
+        <span class="l verdict pass"><span class="badge">✓ ready</span><span class="code">7 plugins available</span></span>
+        <span class="l comment"># or from your shell — claude plugin marketplace add · claude plugin install</span>
+      </div>
+    </div>
+
+    <div class="mkt-grid">
+      <!-- 07 -->
+      <article class="pcard obs">
+        <h3><span class="no">07</span>context-hogs</h3>
+        <p>Per-file context-cost leaderboard — which files eat your tokens.</p>
+        <span class="cmd">/context-hogs:leaderboard</span>
+        <div class="events"><span class="tag evt">PostToolUse</span><span class="tag evt">SessionEnd</span></div>
+      </article>
+      <!-- 08 -->
+      <article class="pcard obs">
+        <h3><span class="no">08</span>nerf-receipts</h3>
+        <p>Personal model-quality flight recorder — your own receipts when Claude feels nerfed.</p>
+        <span class="cmd">/nerf-receipts:receipts</span>
+        <div class="events"><span class="tag evt">SessionStart</span><span class="tag evt">PostToolUse</span><span class="tag evt">PostToolUseFailure</span><span class="tag evt">Stop</span><span class="tag evt">SubagentStop</span><span class="tag evt">SessionEnd</span></div>
+      </article>
+      <!-- 09 -->
+      <article class="pcard obs">
+        <h3><span class="no">09</span>dead-rules-audit</h3>
+        <p>CLAUDE.md compliance scorecard — which rules Claude actually ignores.</p>
+        <span class="cmd">/dead-rules-audit:scorecard</span>
+        <div class="events"><span class="tag evt">SessionStart</span><span class="tag evt">PostToolUse</span><span class="tag evt">SessionEnd</span></div>
+      </article>
+      <!-- 10 -->
+      <article class="pcard obs">
+        <h3><span class="no">10</span>pr-provenance-stamp</h3>
+        <p>Stamps a prompts / spend / tests / agent-authored receipt into PR bodies on <em style="font-style:normal;color:var(--text)">gh pr create</em>.</p>
+        <span class="cmd">/pr-provenance-stamp:provenance</span>
+        <div class="events"><span class="tag evt">PreToolUse</span><span class="tag evt">PostToolUse</span></div>
+      </article>
+      <!-- 11 -->
+      <article class="pcard obs">
+        <h3><span class="no">11</span>standup-autopilot</h3>
+        <p>Writes your standup from what your agents actually did; re-injects yesterday's blockers.</p>
+        <span class="cmd">/standup-autopilot:standup</span>
+        <div class="events"><span class="tag evt">SessionStart</span><span class="tag evt">Stop</span><span class="tag evt">SessionEnd</span></div>
+      </article>
+      <!-- 12 -->
+      <article class="pcard obs">
+        <h3><span class="no">12</span>dead-end-registry</h3>
+        <p>Remembers tried-and-reverted approaches; warns before you pay for a dead end twice.</p>
+        <span class="cmd">/dead-end-registry:dead-ends</span>
+        <div class="events"><span class="tag evt">UserPromptSubmit</span><span class="tag evt">PreToolUse</span><span class="tag evt">Stop</span><span class="tag evt">SubagentStop</span><span class="tag evt">PreCompact</span></div>
+      </article>
+      <!-- 13 -->
+      <article class="pcard obs">
+        <h3><span class="no">13</span>bounty-board</h3>
+        <p>Prices TODO/FIXME debt as aging XP bounties; agents clear them as side quests.</p>
+        <span class="cmd">/bounty-board:board</span>
+        <div class="events"><span class="tag evt">SessionStart</span><span class="tag evt">PostToolUse</span><span class="tag evt">SessionEnd</span></div>
+      </article>
+    </div>
+
+    <p class="mkt-note">
+      Most recorders observe off the critical path — their <b>PostToolUse</b> and <b>Stop</b> hooks run <b>async: true</b>, so they write their receipts without adding latency to the agent loop. The exception is a hook whose output Claude reads back: <b>bounty-board</b> verifies and pays out its bounties synchronously.
+    </p>
+  </section>
+
   <!-- ═══════ INSTALL ═══════ -->
   <section class="section" id="install">
     <div class="sec-head">
       <div>
-        <div class="kicker">Apparatus</div>
+        <div class="kicker">The classic path</div>
         <h2>Copy. Register. Restart.</h2>
+        <p style="font-family:var(--mono);font-size:.76rem;color:var(--faint);margin-top:.7rem">This is the copy-paste six. The seven plugins install with <a href="#marketplace" style="color:var(--pass);border-bottom:1px solid var(--pass-dim)">/plugin ↑</a> instead.</p>
       </div>
       <div class="aside">~60 seconds<br>no build step</div>
     </div>
@@ -646,14 +745,13 @@
       <div class="aside">contributions welcome<br>see CONTRIBUTING.md</div>
     </div>
     <div class="index">
-      <div class="ix"><span class="n">07</span><span class="nm">protect-tests <span>— block test deletion or disabling</span></span><span class="evt">PreToolUse</span></div>
-      <div class="ix"><span class="n">08</span><span class="nm">context-snapshot <span>— preserve before compaction</span></span><span class="evt">PreCompact</span></div>
-      <div class="ix"><span class="n">09</span><span class="nm">session-summary <span>— generate a digest on Stop</span></span><span class="evt">Stop</span></div>
-      <div class="ix"><span class="n">10</span><span class="nm">ntfy-notify <span>— free mobile push</span></span><span class="evt">Notification</span></div>
-      <div class="ix"><span class="n">11</span><span class="nm">discord-notify <span>— webhook alerts</span></span><span class="evt">Notification</span></div>
-      <div class="ix"><span class="n">12</span><span class="nm">tts-alerts <span>— voice notifications via say/espeak</span></span><span class="evt">Notification</span></div>
-      <div class="ix"><span class="n">13</span><span class="nm">rules-injector <span>— auto-attach CLAUDE.md</span></span><span class="evt">UserPromptSubmit</span></div>
-      <div class="ix"><span class="n">14</span><span class="nm">rate-limiter <span>— cap tool calls per minute</span></span><span class="evt">PreToolUse</span></div>
+      <div class="ix"><span class="n">14</span><span class="nm">protect-tests <span>— block test deletion or disabling</span></span><span class="evt">PreToolUse</span></div>
+      <div class="ix"><span class="n">15</span><span class="nm">context-snapshot <span>— preserve before compaction</span></span><span class="evt">PreCompact</span></div>
+      <div class="ix"><span class="n">16</span><span class="nm">ntfy-notify <span>— free mobile push</span></span><span class="evt">Notification</span></div>
+      <div class="ix"><span class="n">17</span><span class="nm">discord-notify <span>— webhook alerts</span></span><span class="evt">Notification</span></div>
+      <div class="ix"><span class="n">18</span><span class="nm">tts-alerts <span>— voice notifications via say/espeak</span></span><span class="evt">Notification</span></div>
+      <div class="ix"><span class="n">19</span><span class="nm">rules-injector <span>— auto-attach CLAUDE.md</span></span><span class="evt">UserPromptSubmit</span></div>
+      <div class="ix"><span class="n">20</span><span class="nm">rate-limiter <span>— cap tool calls per minute</span></span><span class="evt">PreToolUse</span></div>
     </div>
   </section>
 


### PR DESCRIPTION
## What

Content pass for the plugin marketplace launch, across two files.

### `CONTRIBUTING.md`
- Rewrites the guide around the **two contribution paths**: a copy-paste classic hook under `hook-scripts/`, versus an installable plugin bundle under `plugins/<name>/` (hooks + skill + tests, wired via the marketplace, no manual `settings.json`).
- Documents the plugin contract that the shipped plugins actually follow: `plugin.json` is metadata-only, `hooks/hooks.json` wiring, the `async: true` rule (async for pure recorders only; sync for any event whose output Claude consumes), the `--render` skill contract, hermetic tests, the three registration touchpoints, and a pre-PR validation checklist.
- **Hook & plugin ideas:** narrowed the "Block writes to protected branches" bullet. The shipped `hook-scripts/pre-tool-use/git-safety.js` already denies commit/merge/rebase/reset/push on the hardcoded `main`/`master` at its default `high` level, so the bullet now scopes the *open* work to a configurable branch list or non-git write paths (editor writes, `>` redirects) — the same way the rewrite dropped the now-shipped SessionStart context-injection idea.

### `site/index.html`
- Adds the marketplace section: 7 plugin cards (07–13), a nav entry, and the retitled catalog.
- Tightens the `mkt-note`: it previously implied every recorder's `PostToolUse` runs `async: true`. That is not universally true — `bounty-board`'s `PostToolUse` is synchronous because it verifies and pays out bounties whose result Claude reads back. Copy now says "most recorders" and calls out the exception.
- Retires the `session-summary — generate a digest on Stop` forthcoming row: it overlaps the now-shipped `standup-autopilot`, whose `Stop` hook already produces a session digest. Remaining forthcoming rows renumber cleanly to 14–20; no stated count breaks.

## Review process
Both files went through a content review (CONTRIBUTING and SITE verdicts: pass, no must-fix). Every should-fix above was verified against the actual repo files — `git-safety.js` `PATTERNS`/`PROTECTED_BRANCHES`, and each plugin's `hooks/hooks.json` `async` flags — before editing.

## Checks
- Structural self-checks on `site/index.html`: tag balance (section/article/div), anchor targets, and no duplicate ids — all pass.
- `env -u CCH_SLA_WEBHOOK npm test` → **1092 passing, 0 failing** (these two files aren't under test, but the gate holds).

## Deploy
Merging auto-deploys the site via `deploy-pages.yml`.