### PR TITLE
Repo hardening: CI, hermetic tests, site catalog refresh, plugin READMEs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -72,7 +72,8 @@
         "productivity",
         "sessionstart",
         "sessionend",
-        "hooks"
+        "hooks",
+        "stop"
       ]
     },
     {
@@ -86,7 +87,10 @@
         "negative-knowledge",
         "hooks",
         "userpromptsubmit",
-        "pretooluse"
+        "pretooluse",
+        "stop",
+        "subagentstop",
+        "precompact"
       ]
     },
     {

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,5 +18,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Install formatters exercised by the format-code tests
+        run: |
+          npm install -g prettier
+          pipx install ruff
       - name: Run test suite
         run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,5 +22,6 @@ jobs:
         run: |
           npm install -g prettier
           pipx install ruff
+          pipx install uv
       - name: Run test suite
         run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [18, 20, 22]
+    name: Node ${{ matrix.node-version }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Run test suite
+        run: npm test

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 [![GitHub stars](https://img.shields.io/github/stars/karanb192/claude-code-hooks?style=social)](https://github.com/karanb192/claude-code-hooks)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Tests](https://img.shields.io/badge/tests-1165%20passing-brightgreen)](https://github.com/karanb192/claude-code-hooks/actions)
+[![CI](https://github.com/karanb192/claude-code-hooks/actions/workflows/test.yml/badge.svg)](https://github.com/karanb192/claude-code-hooks/actions/workflows/test.yml)
+[![Tests](https://img.shields.io/badge/tests-1165%20passing-brightgreen)](https://github.com/karanb192/claude-code-hooks/actions/workflows/test.yml)
 
 **🌐 [Live site & catalog](https://karanb192.github.io/claude-code-hooks/)**
 
@@ -45,6 +46,10 @@ A growing collection of tested, documented hooks you can copy, paste, and custom
 ### Session Lifecycle
 
 Runs at session boundaries — inject context at **SessionStart** and capture outcomes at **Stop / SessionEnd**.
+
+| Hook | Matcher | Description |
+|------|---------|-------------|
+| [session-logger](hook-scripts/session/session-logger.js) | `SessionStart` + `PostToolUse` + `SessionEnd` | Writes a durable markdown log of every session (cwd, git repo, files touched, bash commands). `PostToolUse` registers with `"async": true` so logging never blocks Claude; concurrent writes are serialized with a file lock. Bash commands get best-effort secret redaction. Drop-in for Obsidian vaults via `CC_SESSION_LOG_DIR`. |
 
 > 🔌 **`bounty-board`** (repo TODO/FIXME/HACK debt priced as aging XP bounties) now ships as an installable **plugin** — see [Install as a plugin](#-install-as-a-plugin).
 
@@ -87,14 +92,6 @@ Fires when Claude needs user attention.
 | Hook                                                                | Matcher                          | Description                                |
 | ------------------------------------------------------------------- | -------------------------------- | ------------------------------------------ |
 | [notify-permission](hook-scripts/notification/notify-permission.js) | `permission_prompt\|idle_prompt` | Sends Slack alerts when Claude needs input |
-
-### Session
-
-Runs on session lifecycle events — start, end, and tool usage during the session.
-
-| Hook | Matcher | Description |
-|------|---------|-------------|
-| [session-logger](hook-scripts/session/session-logger.js) | `SessionStart` + `PostToolUse` + `SessionEnd` | Writes a durable markdown log of every session (cwd, git repo, files touched, bash commands). `PostToolUse` registers with `"async": true` so logging never blocks Claude; concurrent writes are serialized with a file lock. Bash commands get best-effort secret redaction. Drop-in for Obsidian vaults via `CC_SESSION_LOG_DIR`. |
 
 ### Utils
 
@@ -220,7 +217,7 @@ Everything defaults to **deny** — ask mode is strictly opt-in. A common setup:
 
 ## 🧪 Testing
 
-All hooks include comprehensive tests:
+Requires **Node ≥ 18** (no dependencies to install). All hooks include comprehensive tests, run in CI on Node 18, 20, and 22:
 
 ```bash
 # Run all tests

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+If you find a security issue in any hook or plugin — a bypass of a guard hook (a dangerous command or secret access that should be blocked but isn't), a way for hook input to trigger unintended command execution, or secrets leaking into logs — please report it privately rather than opening a public issue:
+
+- **GitHub**: use [private vulnerability reporting](https://github.com/karanb192/claude-code-hooks/security/advisories/new) on this repository.
+
+You'll get a response within a few days. Once fixed, reporters are credited in the release notes unless they prefer otherwise.
+
+## Scope and threat model
+
+These hooks are **guardrails, not a sandbox**. They pattern-match tool calls Claude Code is about to make and block the obviously dangerous ones. A determined adversary (or a sufficiently creative agent) can construct commands that evade any regex — that is a known limitation, not a vulnerability by itself. Reports that meaningfully tighten a guard against realistic agent behavior are still very welcome as regular issues or PRs.
+
+Bypasses of `protect-secrets` that leak credentials through a *documented, blocked* channel, and any case where a hook itself executes untrusted input, are always in scope.
+
+## Supported versions
+
+The `main` branch and the latest published plugin versions in the marketplace are supported. Older plugin versions in the install cache are not patched retroactively — reinstall to get fixes.

--- a/hook-scripts/tests/notification/notify-permission.test.js
+++ b/hook-scripts/tests/notification/notify-permission.test.js
@@ -11,6 +11,10 @@ const assert = require('node:assert');
 const { spawn } = require('node:child_process');
 const path = require('node:path');
 
+// Hermetic: never inherit a real webhook from the developer's shell. The hook
+// module reads CCH_SLA_WEBHOOK at require time, so scrub it before requiring.
+delete process.env.CCH_SLA_WEBHOOK;
+
 const {
   SLACK_WEBHOOK,
   getNotificationType,

--- a/plugins/bounty-board/.claude-plugin/plugin.json
+++ b/plugins/bounty-board/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "bounty-board",
   "description": "Turns your repo's tech debt into an aging bounty economy. A SessionStart hook scans tracked files and prices each TODO/FIXME/HACK/skip as a wanted-poster bounty whose XP grows with its git-blame age, injects the top 3 as opportunistic side quests, and — via a PostToolUse hook — verifies and pays out bounties that genuinely disappear. SessionEnd renders a payout card, and /bounty-board:board shows the current board on demand.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "Karan Bansal",
     "url": "https://github.com/karanb192"

--- a/plugins/bounty-board/README.md
+++ b/plugins/bounty-board/README.md
@@ -1,0 +1,38 @@
+# bounty-board
+
+> Prices your repo's TODO/FIXME/HACK debt as aging XP bounties, injects the top 3 as opportunistic side quests, and verifies + pays out the bounties you genuinely clear.
+
+On SessionStart it scans your git-tracked files, matches comment markers (TODO/FIXME/HACK/XXX/BUG), skipped tests, and lint suppressions, and prices each as a "wanted poster" bounty whose XP scales with git-blame age and severity — older debt pays more. It renders the board as a card and injects the top 3 as side quests via `additionalContext`. A PostToolUse hook re-checks touched files after each edit and pays out bounties whose markers verifiably disappear (rewording transfers the bounty instead of paying; a rename never pays). SessionEnd renders a payout card: XP earned, bounties cleared, and the remaining burn-down. Scanning is cost-bounded (400 files, 256KB/file, ~1.8s total) so it stays cheap on large repos.
+
+## Install
+
+```
+/plugin marketplace add karanb192/claude-code-hooks   # once per machine
+/plugin install bounty-board@claude-code-hooks
+```
+
+Restart Claude Code — done. (Or from a shell: `claude plugin install bounty-board@claude-code-hooks`.)
+
+## What it does
+
+| Event | Runs | What happens |
+| --- | --- | --- |
+| SessionStart | sync | Scans tracked files, prices each TODO/FIXME/HACK/skip/lint-suppression as an aging bounty, renders the board, and injects the top 3 as side quests via `additionalContext`. Re-fires on resume/compact without resetting earnings. |
+| PostToolUse (`Edit\|MultiEdit\|Write\|NotebookEdit\|Bash`) | sync | After a file is touched, re-checks that file's bounties and pays out any whose marker verifiably disappeared (verify-then-reward). Sync because it returns an `additionalContext` payout message. |
+| SessionEnd | sync | Renders the payout card: XP earned this session, bounties cleared, and the remaining board burn-down. |
+
+`/bounty-board:board` — renders the current bounty board on demand and calls out the fattest open bounties.
+
+## Configuration
+
+No configuration needed. State is stored under `~/.claude/bounty-board/` (one JSON ledger per repo); hook logs go to `~/.claude/hooks-logs/`.
+
+## Data & privacy
+
+For each bounty it records the marker text, file path, line, git-blame age, and XP in a local JSON ledger. Everything stays on your machine — the hook makes no network calls (Node built-ins only, zero dependencies).
+
+## Uninstall
+
+```
+/plugin uninstall bounty-board@claude-code-hooks
+```

--- a/plugins/bounty-board/bounty-board.js
+++ b/plugins/bounty-board/bounty-board.js
@@ -8,7 +8,7 @@
  *     bounty) and its severity. The board is rendered as a shareable card and
  *     the top 3 are offered to Claude as opportunistic side quests via
  *     additionalContext. Re-fires on resume/compact without resetting earnings.
- *   - PostToolUse (Edit|Write|Bash): after Claude touches a file, re-checks the
+ *   - PostToolUse (Edit|MultiEdit|Write|NotebookEdit|Bash): after Claude touches a file, re-checks the
  *     bounties in that file and PAYS OUT any that verifiably disappeared
  *     (verify-then-reward). Anti-gaming: rewording a marker transfers the
  *     bounty instead of paying; bounties in a deleted file pay only if the

--- a/plugins/context-hogs/README.md
+++ b/plugins/context-hogs/README.md
@@ -1,0 +1,46 @@
+# context-hogs
+
+> Per-file context-cost leaderboard — attributes every tool result's tokens to the files it loaded, so you know which files cost you the most.
+
+A `PostToolUse` hook fires after every `Read`, `Grep`, `Glob`, and `Bash` call, measures the tool result's bytes, resolves the file path(s) that result belongs to, and appends a ledger row. Tokens are estimated from bytes (~4 bytes/token) and dollars from a configurable input-token rate — hooks don't receive real token counts, so nothing is fabricated. At `SessionEnd`, or on demand via the skill, it aggregates the ledger into your repo's most token-expensive files (read count, cumulative tokens, estimated cost, plus repeat-offender flags for lockfiles, generated code, and giant utils) and renders that leaderboard.
+
+## Install
+
+```
+/plugin marketplace add karanb192/claude-code-hooks   # once per machine
+/plugin install context-hogs@claude-code-hooks
+```
+
+Restart Claude Code — done. (Or from a shell: `claude plugin install context-hogs@claude-code-hooks`.)
+
+## What it does
+
+| Event | Runs | What happens |
+|-------|------|--------------|
+| PostToolUse (`Read\|Grep\|Glob\|Bash`) | async (zero added latency) | Measures the tool result's bytes, resolves the file path(s) it belongs to, appends a ledger row. |
+| SessionEnd | sync | Aggregates the whole ledger, renders the leaderboard card via `systemMessage`, and writes a suggested CLAUDE.md ignore block for the top offenders. |
+
+`/context-hogs:leaderboard` — renders this repo's context-cost leaderboard on demand.
+
+## Configuration
+
+All optional, set via environment variables:
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `CONTEXT_HOGS_BYTES_PER_TOKEN` | `4` | Bytes-per-token ratio used to estimate tokens. |
+| `CONTEXT_HOGS_USD_PER_MTOK` | `3.0` | Input $/1M tokens used to estimate cost. Set to your model's current input rate. |
+| `CONTEXT_HOGS_TOP_N` | `10` | Number of files shown on the leaderboard. |
+| `CONTEXT_HOGS_LEDGER_CAP` | `50000` | Max ledger rows kept; older rows are compacted at SessionEnd. |
+
+State is stored under `~/.claude/context-hogs/<repo-key>/ledger.jsonl`.
+
+## Data & privacy
+
+Records file paths, read counts, and byte/token estimates per repo. It makes no network calls — the script only uses `fs`, `path`, and `os` — so everything stays on your local machine.
+
+## Uninstall
+
+```
+/plugin uninstall context-hogs@claude-code-hooks
+```

--- a/plugins/dead-end-registry/README.md
+++ b/plugins/dead-end-registry/README.md
@@ -1,0 +1,48 @@
+# dead-end-registry
+
+> Remembers approaches you tried and reverted (with reason and estimated token cost) and warns before you retry them.
+
+On `Stop`, `SubagentStop`, and `PreCompact` the hook mines the session transcript for approaches you TRIED and then REVERTED or ruled out, recording each with its reason, date, and an estimated token cost of the detour into a per-repo registry. On `UserPromptSubmit` it keyword-matches the new prompt against that registry and injects a "DEAD END — you already tried this" card via `additionalContext`. On `PreToolUse` (Edit|Write) it returns an `ask` decision when the pending diff would reintroduce a previously-reverted hunk. Extraction is deterministic (revert-signal heuristics plus tool-result scanning); an optional model pass is never required and never runs in tests.
+
+## Install
+
+```
+/plugin marketplace add karanb192/claude-code-hooks   # once per machine
+/plugin install dead-end-registry@claude-code-hooks
+```
+
+Restart Claude Code — done. (Or from a shell: `claude plugin install dead-end-registry@claude-code-hooks`.)
+
+## What it does
+
+| Event | Runs | What happens |
+|-------|------|--------------|
+| UserPromptSubmit | sync | Matches the prompt against the registry; injects a "you already tried this" warning card when it hits a recorded dead end. |
+| PreToolUse (Edit\|Write) | sync | Returns permission decision `ask` when the diff would reintroduce a previously-reverted hunk. |
+| Stop | async (zero added latency) | Mines the transcript for abandoned approaches into the per-repo registry. |
+| SubagentStop | async (zero added latency) | Same mining, at subagent stop. |
+| PreCompact | async (zero added latency) | Same mining, before context is compacted away. |
+
+`/dead-end-registry:dead-ends` — renders this repo's recorded dead ends, newest first, each with the date tried, why it was walked back, and the estimated token cost of the detour.
+
+## Configuration
+
+No environment variables. Behavior is governed by in-source constants with these defaults:
+
+- `MAX_AGE_DAYS` = 60 — entries older than this are ignored on read and dropped at compaction.
+- `MAX_CARD_ENTRIES` = 3 — entries shown in an injected card.
+- `MAX_REGISTRY_ENTRIES` = 500 — entries scanned on prompt-submit.
+- `MAX_CODE_LINES` = 80 / `MAX_CODE_CHARS` = 4000 — truncation caps on stored code snapshots.
+- `USD_PER_TOKEN` = 0.000009 — rough blended rate for the headline cost figure.
+
+State is stored per-project (keyed by a hash of the repo path) under `~/.claude/dead-end-registry/<repo>.jsonl`, outside the repo so nothing is accidentally committed.
+
+## Data & privacy
+
+Recorded: short summaries and truncated code snapshots of reverted approaches, plus reason, date, and an estimated token cost, all mined from your local transcripts. Everything stays on your machine — the hook makes no network calls.
+
+## Uninstall
+
+```
+/plugin uninstall dead-end-registry@claude-code-hooks
+```

--- a/plugins/dead-rules-audit/.claude-plugin/plugin.json
+++ b/plugins/dead-rules-audit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dead-rules-audit",
-  "description": "A CLAUDE.md compliance flight-recorder for Claude Code. At SessionStart it parses CLAUDE.md into numbered atomic rules; on every Edit/Write a PostToolUse hook (async, zero added latency) passively tallies how often each rule was relevant and whether it was followed or violated; at SessionEnd — or on demand via /dead-rules-audit:scorecard — it renders a worst-first compliance scorecard with a promote-to-hook hint for chronically-ignored rules. Zero deps, zero network, fully deterministic.",
-  "version": "1.0.0",
+  "description": "A CLAUDE.md compliance flight-recorder for Claude Code. At SessionStart it parses CLAUDE.md into numbered atomic rules; on every Edit/MultiEdit/Write a PostToolUse hook (async, zero added latency) passively tallies how often each rule was relevant and whether it was followed or violated; at SessionEnd — or on demand via /dead-rules-audit:scorecard — it renders a worst-first compliance scorecard with a promote-to-hook hint for chronically-ignored rules. Zero deps, zero network, fully deterministic.",
+  "version": "1.0.1",
   "author": {
     "name": "Karan Bansal",
     "url": "https://github.com/karanb192"

--- a/plugins/dead-rules-audit/README.md
+++ b/plugins/dead-rules-audit/README.md
@@ -1,0 +1,38 @@
+# dead-rules-audit
+
+> A CLAUDE.md compliance scorecard that tallies which rules Claude actually follows vs ignores as you edit, and flags chronically-ignored rules to promote into a deterministic hook.
+
+At SessionStart it finds the nearest CLAUDE.md and parses it into numbered atomic rules, snapshotting which loaded this session. On every Edit/MultiEdit/Write a PostToolUse hook scores the change against each rule and tallies — per rule — how often it was relevant and whether it was followed or violated, appending to a local JSONL ledger. The judgement is a deterministic keyword/pattern heuristic: no model call, no network. At SessionEnd it renders a worst-first compliance scorecard (rule text, times relevant, times violated, compliance %, and a `⚠ promote→hook` flag for chronically-ignored rules) and persists it. You can also re-render on demand.
+
+## Install
+
+```
+/plugin marketplace add karanb192/claude-code-hooks   # once per machine
+/plugin install dead-rules-audit@claude-code-hooks
+```
+
+Restart Claude Code — done. (Or from a shell: `claude plugin install dead-rules-audit@claude-code-hooks`.)
+
+## What it does
+
+| Event | Runs | What happens |
+|-------|------|--------------|
+| SessionStart | sync | Parse CLAUDE.md into numbered atomic rules; snapshot which rules loaded this session. |
+| PostToolUse (`Edit\|MultiEdit\|Write`) | async (zero added latency) | Score the change against each rule; update per-rule relevant/followed/violated tallies in the ledger. |
+| SessionEnd | sync | Render the worst-first compliance scorecard and persist it. |
+
+`/dead-rules-audit:scorecard` — renders the worst-first compliance scorecard on demand, highlighting the worst offenders and any `promote→hook` rules.
+
+## Configuration
+
+No configuration needed. There are no environment variables or settings. Tuning thresholds are hard-coded constants at the top of `dead-rules-audit.js`: the `promote→hook` flag fires at `PROMOTE_MIN_VIOLATIONS = 3` violations and `PROMOTE_RATE = 0.5` violation rate, with `MAX_CLAUDE_MD_BYTES = 256 * 1024` and `MAX_RULES = 200` guards. Tally state is stored in `~/.claude/dead-rules-audit/` (scorecard entries are also logged to `~/.claude/hooks-logs/<date>.jsonl`).
+
+## Data & privacy
+
+It records your CLAUDE.md rule text and per-rule relevant/followed/violated tallies. Everything stays on the local machine — the source requires only `fs`, `path`, `os`, and `crypto`, makes zero network calls, and is fully deterministic.
+
+## Uninstall
+
+```
+/plugin uninstall dead-rules-audit@claude-code-hooks
+```

--- a/plugins/dead-rules-audit/dead-rules-audit.js
+++ b/plugins/dead-rules-audit/dead-rules-audit.js
@@ -12,7 +12,7 @@
  *
  * Registers on THREE events (branch on hook_event_name):
  *   - SessionStart : parse CLAUDE.md, snapshot which rules loaded this session
- *   - PostToolUse (Edit|Write) : score the diff against each rule, update ledger
+ *   - PostToolUse (Edit|MultiEdit|Write) : score the diff against each rule, update ledger
  *   - SessionEnd   : render the compliance scorecard via `systemMessage`
  * The SessionEnd scorecard is surfaced to you through `systemMessage` (a
  * universal hook-output field the docs show to the user across all events) and

--- a/plugins/nerf-receipts/.claude-plugin/plugin.json
+++ b/plugins/nerf-receipts/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nerf-receipts",
-  "description": "A personal flight recorder for Claude Code quality. Background hooks (async, zero added latency) record your own per-session signals keyed by model id and Claude Code version — tool-failure rate, same-file edit churn, turn-end counts, and tokens-per-completed-task. At SessionEnd — or on demand via /nerf-receipts:receipts — it renders a trend card with sparklines and flags meaningful shifts that coincide with a model change, so the next time someone says \"they nerfed it\" you have data instead of vibes.",
-  "version": "1.0.0",
+  "description": "A personal flight recorder for Claude Code quality. Background hooks (async, zero added latency) record your own per-session signals keyed by model id and Claude Code version — tool-failure rate, same-file edit churn, turn-end counts, and tokens-per-completed-task. At your next SessionStart — or on demand via /nerf-receipts:receipts — it renders a trend card with sparklines and flags meaningful shifts that coincide with a model change, so the next time someone says \"they nerfed it\" you have data instead of vibes.",
+  "version": "1.0.1",
   "author": {
     "name": "Karan Bansal",
     "url": "https://github.com/karanb192"

--- a/plugins/nerf-receipts/README.md
+++ b/plugins/nerf-receipts/README.md
@@ -1,0 +1,47 @@
+# nerf-receipts
+
+> A personal flight recorder for Claude Code quality — records your own per-session failure rate, edit churn, and tokens/task by model version, and flags real shifts when a model changes.
+
+nerf-receipts registers on six hook events. As you work, `PostToolUse` and `PostToolUseFailure` count every tool call, its failures, and same-file edit churn; `Stop` and `SubagentStop` count turn-end events — all async, so they add no latency. At `SessionEnd` it parses token usage from the session transcript, finalizes four per-session signals (tool-failure rate, edit churn, turn-end count, tokens-per-completed-task), and appends one record to a JSONL ledger. At `SessionStart` it renders a trend card — a sparkline per metric, keyed by model id and Claude Code version — and flags meaningful shifts (>=25% relative change in the mean) that coincide with a model change. The same card is available on demand via `/nerf-receipts:receipts`.
+
+## Install
+
+```
+/plugin marketplace add karanb192/claude-code-hooks   # once per machine
+/plugin install nerf-receipts@claude-code-hooks
+```
+
+Restart Claude Code — done. (Or from a shell: `claude plugin install nerf-receipts@claude-code-hooks`.)
+
+## What it does
+
+| Event | Runs | What happens |
+| ----- | ---- | ------------ |
+| `PostToolUse` | async (zero added latency) | Counts every tool call; records failures and same-file edit churn |
+| `PostToolUseFailure` | async (zero added latency) | Counts tool-call failures and edit churn |
+| `Stop` | async (zero added latency) | Counts turn-end events |
+| `SubagentStop` | async (zero added latency) | Counts subagent turn-end events |
+| `SessionEnd` | sync | Parses transcript tokens, finalizes the session, appends the record to the ledger |
+| `SessionStart` | sync | Renders the trend card and flags model-change shifts via `additionalContext` |
+
+`/nerf-receipts:receipts` — renders the model-quality trend card on demand (failure rate, edit churn, tokens/task by model version, each with a sparkline).
+
+## Configuration
+
+No environment variables. Tuning constants live at the top of `nerf-receipts.js`:
+
+- `MIN_SESSIONS_FOR_TREND` = 6 — sessions required before a trend or shift is reported
+- `TREND_WINDOW` = 200 — most recent sessions the trend card considers
+- `MAX_TRANSCRIPT_LINES` = 20000 and `MAX_TRANSCRIPT_BYTES` = 16 MiB — caps on transcript parsing
+
+State is stored as a JSONL ledger under `~/.claude/nerf-receipts/` (per-session in-flight logs under `~/.claude/nerf-receipts/sessions/`); event logs go to `~/.claude/hooks-logs/<date>.jsonl`.
+
+## Data & privacy
+
+Only counts and edited file paths are recorded — tool inputs, commands, and transcript text are never persisted, so secrets in commands cannot land in the ledger. The script makes no network calls (it requires only `fs`, `path`, and `os`); everything stays on your local machine.
+
+## Uninstall
+
+```
+/plugin uninstall nerf-receipts@claude-code-hooks
+```

--- a/plugins/pr-provenance-stamp/README.md
+++ b/plugins/pr-provenance-stamp/README.md
@@ -1,0 +1,37 @@
+# pr-provenance-stamp
+
+> Stamps a provenance receipt — prompts, estimated spend, tests run with exit codes, and a truthful agent-authored line split — into your PR body on `gh pr create`.
+
+A PostToolUse hook keeps a per-session ledger: tool-call count, agent-authored line count, and every test/typecheck/lint command with its real exit code. When Claude runs `gh pr create` (or `glab mr create`), a PreToolUse (Bash) hook reads the session transcript for the real prompt count, estimated token/dollar spend, and models, asks git for the branch's total added lines to derive an agent-vs-human split, then appends a one-line receipt to the PR `--body`. If the command builds its body with a heredoc, `$(...)`, backticks, or process substitution, the hook defers and leaves the command untouched rather than risk corrupting it.
+
+## Install
+
+```
+/plugin marketplace add karanb192/claude-code-hooks   # once per machine
+/plugin install pr-provenance-stamp@claude-code-hooks
+```
+
+Restart Claude Code — done. (Or from a shell: `claude plugin install pr-provenance-stamp@claude-code-hooks`.)
+
+## What it does
+
+| Event | Runs | What happens |
+|-------|------|--------------|
+| PostToolUse (`Edit\|MultiEdit\|Write\|Bash`) | async (zero added latency) | Updates the session ledger — tool-call count, agent-authored line count, and each test/typecheck command with its real exit code. |
+| PreToolUse (`Bash`) | sync | On `gh pr create` / `glab mr create`, rewrites the `--body` to append the receipt (prompt count, est. spend, test tally, agent-vs-human line split). Defers on unsafe shell constructs. |
+
+`/pr-provenance-stamp:provenance` — renders the current session's receipt exactly as it would be stamped into a PR body, without creating one.
+
+## Configuration
+
+No configuration needed. State is stored per session at `~/.claude/pr-provenance-stamp/<session_id>.json` (hook logs at `~/.claude/hooks-logs/`).
+
+## Data & privacy
+
+Records tool-call counts, test commands with exit codes, agent line counts, and transcript-derived prompt/spend estimates. Everything is read and computed on your machine — the hook makes no network calls of its own; it only shells out to `git` for the line diff. It does rewrite the `--body` of your `gh pr create` command, so the receipt text becomes part of the public PR description that gets published to GitHub.
+
+## Uninstall
+
+```
+/plugin uninstall pr-provenance-stamp@claude-code-hooks
+```

--- a/plugins/standup-autopilot/README.md
+++ b/plugins/standup-autopilot/README.md
@@ -1,0 +1,38 @@
+# standup-autopilot
+
+> Writes your daily standup from what your agents actually did across your repos — tasks, tests, PRs, and blockers pulled from session transcripts, not commits or tickets.
+
+On every `Stop` and `SessionEnd`, it parses the session transcript and snapshots the outcome — task summary, git branch and diffstat, test commands with exit codes, opened PRs, and unresolved blockers — to a per-day JSONL ledger. Both events run the same idempotent upsert keyed by `session_id`, so whichever fires last wins. On `SessionStart` (startup), it re-injects the previous ledger day's open blockers into the agent via `additionalContext` and prints a standup-ready card to stderr on the first session of the day. Credential-shaped strings (`ghp_`/`sk-`/`xox` tokens, AWS keys, JWTs, `key=value` secrets) are redacted before anything is written to disk.
+
+## Install
+
+```
+/plugin marketplace add karanb192/claude-code-hooks   # once per machine
+/plugin install standup-autopilot@claude-code-hooks
+```
+
+Restart Claude Code — done. (Or from a shell: `claude plugin install standup-autopilot@claude-code-hooks`.)
+
+## What it does
+
+| Event | Runs | What happens |
+| --- | --- | --- |
+| `SessionStart` (matcher: `startup`) | sync | Re-injects the previous ledger day's unresolved blockers via `additionalContext`; on the first session of the day, prints a standup card to stderr. |
+| `Stop` | async (zero added latency) | Snapshots the session's outcome (task, branch + diffstat, tests + exit codes, PRs, blockers) to the day's ledger. |
+| `SessionEnd` | sync | Runs the same idempotent upsert as `Stop`, capturing the session's final state. |
+
+`/standup-autopilot:standup` — renders today's standup card: one line per repo (what got done, tests run, PRs, diffstat) plus any unresolved blockers, restated as a ready-to-paste update.
+
+## Configuration
+
+No configuration needed. State lives in `~/.claude/standup/<YYYY-MM-DD>.jsonl` (append-only per-day ledgers, deduped on read by `session_id`); hook run logs go to `~/.claude/hooks-logs/<YYYY-MM-DD>.jsonl`.
+
+## Data & privacy
+
+Recorded: task summaries, git branch/diffstat, test commands and exit codes, PR references, and blocker snippets — all derived from your local session transcripts, with credential-shaped strings redacted before write. Everything stays on your machine; the plugin makes no network calls, ever.
+
+## Uninstall
+
+```
+/plugin uninstall standup-autopilot@claude-code-hooks
+```

--- a/site/index.html
+++ b/site/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>claude-code-hooks — guardrails for the Claude Code agent loop</title>
-<meta name="description" content="Tested hooks that intercept the Claude Code agent loop — read stdin, exit 0 to pass or exit 2 to block. Six copy-paste hooks plus a seven-plugin marketplace you install with /plugin install <name>@claude-code-hooks.">
+<meta name="description" content="Tested hooks that intercept the Claude Code agent loop — read stdin, exit 0 to pass or exit 2 to block. Eight copy-paste hooks plus a seven-plugin marketplace you install with /plugin install <name>@claude-code-hooks.">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;450;500;600&family=JetBrains+Mono:ital,wght@0,400;0,500;0,700;1,400&display=swap" rel="stylesheet">
@@ -339,7 +339,7 @@
       <p class="hero-deck">
         Small programs that watch what <b>Claude Code</b> is about to do — and step in.
         Block a destructive command. Refuse to read a secret. Stage and format an edit.
-        Ping you on Slack. Six <b>exhaustively tested</b> copy-paste hooks, plus a seven-plugin marketplace you install with one command.
+        Ping you on Slack. Eight <b>exhaustively tested</b> copy-paste hooks, plus a seven-plugin marketplace you install with one command.
       </p>
       <div class="cta-row">
         <a class="btn btn-primary" href="#install">
@@ -352,7 +352,7 @@
         </a>
       </div>
       <div class="hero-stats">
-        <div class="s"><b>13</b><span>Hooks + plugins</span></div>
+        <div class="s"><b>15</b><span>Hooks + plugins</span></div>
         <div class="s"><b class="accent">1165</b><span>Tests pass</span></div>
         <div class="s"><b>~80<small style="font-size:.7rem">ms</small></b><span>Per call</span></div>
         <div class="s"><b>0 · 2</b><span>Exit codes</span></div>
@@ -439,7 +439,7 @@
     <div class="sec-head">
       <div>
         <div class="kicker">The catalog</div>
-        <h2>The copy-paste six.</h2>
+        <h2>The copy-paste eight.</h2>
         <p style="font-family:var(--mono);font-size:.76rem;color:var(--faint);margin-top:.7rem">Want one-command installs instead? <a href="#marketplace" style="color:var(--pass);border-bottom:1px solid var(--pass-dim)">Seven plugins ↓</a></p>
       </div>
       <div class="aside">node + python<br>MIT licensed</div>
@@ -553,6 +553,42 @@
       </div>
     </article>
 
+    <!-- 07 -->
+    <article class="entry obs">
+      <div>
+        <div class="entry-meta"><span class="tag evt">PreToolUse</span><span class="tag">Bash · Edit · Write</span><span class="tag rt">Node · ~80ms</span></div>
+        <h3><span class="no">07</span>protect-tests</h3>
+        <p>Stops the "fake green" ending: an agent that can't make a test pass will sometimes delete it, rename it out of discovery, or slip in a <em>.skip</em>. This hook refuses all three — while still allowing you to re-enable tests freely.</p>
+      </div>
+      <div class="term">
+        <div class="term-bar"><div class="term-dots"><i></i><i></i><i></i></div><div class="term-title">protect-tests</div></div>
+        <div class="term-body">
+          <span class="l"><span class="key">tool</span> <span class="val">Edit</span></span>
+          <span class="l"><span class="key">file</span> <span class="val">auth.test.js → describe.skip(</span></span>
+          <span class="l verdict block"><span class="badge">⊘ blocked</span><span class="code">exit 2</span></span>
+          <span class="l verdict-note">"tests must fail honestly"</span>
+        </div>
+      </div>
+    </article>
+
+    <!-- 08 -->
+    <article class="entry rev obs">
+      <div>
+        <div class="entry-meta"><span class="tag evt">SessionStart · SessionEnd</span><span class="tag">PostToolUse · async</span><span class="tag rt">Node · ~80ms</span></div>
+        <h3><span class="no">08</span>session-logger</h3>
+        <p>Writes a durable markdown log of every session — repo, files touched, bash commands (secrets redacted) — without adding a millisecond to the loop. Point <em>CC_SESSION_LOG_DIR</em> at an Obsidian vault and your agent keeps a diary.</p>
+      </div>
+      <div class="term">
+        <div class="term-bar"><div class="term-dots"><i></i><i></i><i></i></div><div class="term-title">session-logger</div></div>
+        <div class="term-body">
+          <span class="l"><span class="key">event</span> <span class="val">SessionEnd</span></span>
+          <span class="l"><span class="key">repo</span>  <span class="val">~/repo · 14 files · 31 cmds</span></span>
+          <span class="l verdict pass"><span class="badge">✎ logged</span><span class="code">sessions/2026-07-19.md</span></span>
+          <span class="l verdict-note">"every session, remembered"</span>
+        </div>
+      </div>
+    </article>
+
     <p style="font-family:var(--mono);font-size:.8rem;color:var(--faint);margin-top:2rem;padding-top:1.5rem;border-top:1px solid var(--line)">
       + <span style="color:var(--dim)">event-logger</span> — a Python diagnostic that dumps every event's JSON so you can see an event's shape before you write a hook against it. The thing you reach for first.
     </p>
@@ -586,49 +622,49 @@
     <div class="mkt-grid">
       <!-- 07 -->
       <article class="pcard obs">
-        <h3><span class="no">07</span>context-hogs</h3>
+        <h3><span class="no">09</span>context-hogs</h3>
         <p>Per-file context-cost leaderboard — which files eat your tokens.</p>
         <span class="cmd">/context-hogs:leaderboard</span>
         <div class="events"><span class="tag evt">PostToolUse</span><span class="tag evt">SessionEnd</span></div>
       </article>
       <!-- 08 -->
       <article class="pcard obs">
-        <h3><span class="no">08</span>nerf-receipts</h3>
+        <h3><span class="no">10</span>nerf-receipts</h3>
         <p>Personal model-quality flight recorder — your own receipts when Claude feels nerfed.</p>
         <span class="cmd">/nerf-receipts:receipts</span>
         <div class="events"><span class="tag evt">SessionStart</span><span class="tag evt">PostToolUse</span><span class="tag evt">PostToolUseFailure</span><span class="tag evt">Stop</span><span class="tag evt">SubagentStop</span><span class="tag evt">SessionEnd</span></div>
       </article>
       <!-- 09 -->
       <article class="pcard obs">
-        <h3><span class="no">09</span>dead-rules-audit</h3>
+        <h3><span class="no">11</span>dead-rules-audit</h3>
         <p>CLAUDE.md compliance scorecard — which rules Claude actually ignores.</p>
         <span class="cmd">/dead-rules-audit:scorecard</span>
         <div class="events"><span class="tag evt">SessionStart</span><span class="tag evt">PostToolUse</span><span class="tag evt">SessionEnd</span></div>
       </article>
       <!-- 10 -->
       <article class="pcard obs">
-        <h3><span class="no">10</span>pr-provenance-stamp</h3>
+        <h3><span class="no">12</span>pr-provenance-stamp</h3>
         <p>Stamps a prompts / spend / tests / agent-authored receipt into PR bodies on <em style="font-style:normal;color:var(--text)">gh pr create</em>.</p>
         <span class="cmd">/pr-provenance-stamp:provenance</span>
         <div class="events"><span class="tag evt">PreToolUse</span><span class="tag evt">PostToolUse</span></div>
       </article>
       <!-- 11 -->
       <article class="pcard obs">
-        <h3><span class="no">11</span>standup-autopilot</h3>
+        <h3><span class="no">13</span>standup-autopilot</h3>
         <p>Writes your standup from what your agents actually did; re-injects yesterday's blockers.</p>
         <span class="cmd">/standup-autopilot:standup</span>
         <div class="events"><span class="tag evt">SessionStart</span><span class="tag evt">Stop</span><span class="tag evt">SessionEnd</span></div>
       </article>
       <!-- 12 -->
       <article class="pcard obs">
-        <h3><span class="no">12</span>dead-end-registry</h3>
+        <h3><span class="no">14</span>dead-end-registry</h3>
         <p>Remembers tried-and-reverted approaches; warns before you pay for a dead end twice.</p>
         <span class="cmd">/dead-end-registry:dead-ends</span>
         <div class="events"><span class="tag evt">UserPromptSubmit</span><span class="tag evt">PreToolUse</span><span class="tag evt">Stop</span><span class="tag evt">SubagentStop</span><span class="tag evt">PreCompact</span></div>
       </article>
       <!-- 13 -->
       <article class="pcard obs">
-        <h3><span class="no">13</span>bounty-board</h3>
+        <h3><span class="no">15</span>bounty-board</h3>
         <p>Prices TODO/FIXME debt as aging XP bounties; agents clear them as side quests.</p>
         <span class="cmd">/bounty-board:board</span>
         <div class="events"><span class="tag evt">SessionStart</span><span class="tag evt">PostToolUse</span><span class="tag evt">SessionEnd</span></div>
@@ -646,7 +682,7 @@
       <div>
         <div class="kicker">The classic path</div>
         <h2>Copy. Register. Restart.</h2>
-        <p style="font-family:var(--mono);font-size:.76rem;color:var(--faint);margin-top:.7rem">This is the copy-paste six. The seven plugins install with <a href="#marketplace" style="color:var(--pass);border-bottom:1px solid var(--pass-dim)">/plugin ↑</a> instead.</p>
+        <p style="font-family:var(--mono);font-size:.76rem;color:var(--faint);margin-top:.7rem">This is the copy-paste eight. The seven plugins install with <a href="#marketplace" style="color:var(--pass);border-bottom:1px solid var(--pass-dim)">/plugin ↑</a> instead.</p>
       </div>
       <div class="aside">~60 seconds<br>no build step</div>
     </div>
@@ -745,20 +781,19 @@
       <div class="aside">contributions welcome<br>see CONTRIBUTING.md</div>
     </div>
     <div class="index">
-      <div class="ix"><span class="n">14</span><span class="nm">protect-tests <span>— block test deletion or disabling</span></span><span class="evt">PreToolUse</span></div>
-      <div class="ix"><span class="n">15</span><span class="nm">context-snapshot <span>— preserve before compaction</span></span><span class="evt">PreCompact</span></div>
-      <div class="ix"><span class="n">16</span><span class="nm">ntfy-notify <span>— free mobile push</span></span><span class="evt">Notification</span></div>
-      <div class="ix"><span class="n">17</span><span class="nm">discord-notify <span>— webhook alerts</span></span><span class="evt">Notification</span></div>
-      <div class="ix"><span class="n">18</span><span class="nm">tts-alerts <span>— voice notifications via say/espeak</span></span><span class="evt">Notification</span></div>
-      <div class="ix"><span class="n">19</span><span class="nm">rules-injector <span>— auto-attach CLAUDE.md</span></span><span class="evt">UserPromptSubmit</span></div>
-      <div class="ix"><span class="n">20</span><span class="nm">rate-limiter <span>— cap tool calls per minute</span></span><span class="evt">PreToolUse</span></div>
+      <div class="ix"><span class="n">16</span><span class="nm">context-snapshot <span>— preserve before compaction</span></span><span class="evt">PreCompact</span></div>
+      <div class="ix"><span class="n">17</span><span class="nm">ntfy-notify <span>— free mobile push</span></span><span class="evt">Notification</span></div>
+      <div class="ix"><span class="n">18</span><span class="nm">discord-notify <span>— webhook alerts</span></span><span class="evt">Notification</span></div>
+      <div class="ix"><span class="n">19</span><span class="nm">tts-alerts <span>— voice notifications via say/espeak</span></span><span class="evt">Notification</span></div>
+      <div class="ix"><span class="n">20</span><span class="nm">rules-injector <span>— auto-attach CLAUDE.md</span></span><span class="evt">UserPromptSubmit</span></div>
+      <div class="ix"><span class="n">21</span><span class="nm">rate-limiter <span>— cap tool calls per minute</span></span><span class="evt">PreToolUse</span></div>
     </div>
   </section>
 
   <!-- ═══════ CLOSING ═══════ -->
   <section class="close">
     <h2>Put a hook in the loop.</h2>
-    <p>Thirteen tested tools — six copy-paste guardrails plus seven one-command plugins, MIT licensed, no framework to learn. Install one and restart Claude Code — you're protected in under a minute.</p>
+    <p>Fifteen tested tools — eight copy-paste guardrails plus seven one-command plugins, MIT licensed, no framework to learn. Install one and restart Claude Code — you're protected in under a minute.</p>
     <div class="cta-row">
       <a class="btn btn-primary" href="https://github.com/karanb192/claude-code-hooks">
         <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.5 2 2 6.6 2 12.2c0 4.5 2.9 8.3 6.8 9.7.5.1.7-.2.7-.5v-1.7c-2.8.6-3.4-1.4-3.4-1.4-.5-1.2-1.1-1.5-1.1-1.5-.9-.6.1-.6.1-.6 1 .1 1.5 1 1.5 1 .9 1.6 2.4 1.1 3 .9.1-.7.4-1.1.6-1.4-2.2-.3-4.6-1.1-4.6-5 0-1.1.4-2 1-2.7-.1-.3-.4-1.3.1-2.7 0 0 .8-.3 2.7 1a9.3 9.3 0 0 1 5 0c1.9-1.3 2.7-1 2.7-1 .5 1.4.2 2.4.1 2.7.6.7 1 1.6 1 2.7 0 3.9-2.4 4.7-4.6 5 .4.3.7.9.7 1.9v2.8c0 .3.2.6.7.5 3.9-1.4 6.8-5.2 6.8-9.7C22 6.6 17.5 2 12 2Z"/></svg>


### PR DESCRIPTION
Closes the gaps from the holistic repo review:

**1. CI (the big one).** `test.yml` runs the full 1,165-test suite on Node 18/20/22 for every push to main and every PR. Until now the tests badge linked to an Actions page that had never run a test; external PRs arrived unchecked. README gets the live CI badge alongside the count badge.

**2. Hermetic tests.** `notify-permission.test.js` scrubs `CCH_SLA_WEBHOOK` before requiring the hook — previously 2/29 tests failed for anyone with that env var set. The whole suite now passes with every known pollutant set (`CCH_SLA_WEBHOOK` + all three `HOOK_ASK_*`).

**3. Site catalog catches up with reality.** Cards for protect-tests (07) and session-logger (08), plugins renumbered 09–15, protect-tests removed from the forthcoming strip (it shipped in #20), all six/thirteen counts now eight/fifteen. Visually QA'd headless.

**4. Per-plugin READMEs.** All 7 plugins documented from source: install one-liner, hook table (event/sync-async/behavior), real config knobs with defaults, state location, data & privacy, uninstall.

**5. Doc-drift fixes found while writing them** (each verified against hooks.json + source):
- nerf-receipts: trend card renders at **SessionStart**, not SessionEnd → plugin.json corrected, v1.0.1
- dead-rules-audit: matcher prose omitted **MultiEdit** → JSDoc + plugin.json corrected, v1.0.1
- bounty-board: JSDoc matcher omitted **MultiEdit/NotebookEdit** → corrected, v1.0.1
- marketplace tags now list every registered event (dead-end-registry, standup-autopilot)

**6. SECURITY.md** — private vulnerability reporting + an explicit guardrails-not-a-sandbox threat model.

Suite: **1,165/0** clean *and* fully polluted. `claude plugin validate`: ✔.