### PR TITLE
fix(auto-stage): stage files without a shell

### DIFF
--- a/hook-scripts/post-tool-use/auto-stage.js
+++ b/hook-scripts/post-tool-use/auto-stage.js
@@ -24,7 +24,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { execSync } = require('child_process');
+const { execSync, execFileSync } = require('child_process');
 
 const LOG_DIR = path.join(process.env.HOME, '.claude', 'hooks-logs');
 
@@ -49,7 +49,10 @@ function isInGitRepo(filePath) {
 function stageFile(filePath) {
   try {
     const dir = path.dirname(filePath);
-    execSync(`git add "${filePath}"`, { cwd: dir, stdio: 'pipe' });
+    // No shell: the path is passed as an argv element, so quotes, $(), and
+    // backticks in a filename cannot break out. `--` stops a leading dash
+    // from being read as a git option.
+    execFileSync('git', ['add', '--', filePath], { cwd: dir, stdio: 'pipe' });
     return { success: true };
   } catch (e) {
     return { success: false, error: e.message };

--- a/hook-scripts/tests/post-tool-use/auto-stage.test.js
+++ b/hook-scripts/tests/post-tool-use/auto-stage.test.js
@@ -99,6 +99,36 @@ describe('Unit: stageFile()', () => {
     const result = stageFile(path.join(tempDir, 'nonexistent.txt'));
     assert.ok('success' in result);
   });
+
+  it('stages a filename containing shell metacharacters without executing them', () => {
+    // Regression: stageFile used to interpolate the path into a shell string,
+    // so a filename like a"b$(...).txt escaped the quotes and ran the command.
+    // Relative sentinel: git runs with cwd = dirname(filePath), so a shell
+    // would drop the file right here. A path separator cannot go in a filename.
+    const sentinel = path.join(tempDir, 'pwned');
+    const nasty = path.join(tempDir, 'a"b$(touch pwned).txt');
+    fs.writeFileSync(nasty, 'x');
+
+    const result = stageFile(nasty);
+
+    assert.strictEqual(fs.existsSync(sentinel), false, 'command substitution must not run');
+    assert.strictEqual(result.success, true);
+    // -z gives raw NUL-separated names; without it git escapes the quotes.
+    const staged = execSync('git diff --cached --name-only -z', { cwd: tempDir, encoding: 'utf8' })
+      .split('\0')
+      .filter(Boolean);
+    assert.ok(
+      staged.includes(path.basename(nasty)),
+      'the literal filename should be staged'
+    );
+  });
+
+  it('stages a filename starting with a dash', () => {
+    // `--` keeps git from reading the leading dash as an option.
+    const dashed = path.join(tempDir, '-dashed.txt');
+    fs.writeFileSync(dashed, 'x');
+    assert.strictEqual(stageFile(dashed).success, true);
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## The problem

`stageFile()` builds a shell command string from the file path:

```js
execSync(`git add "${filePath}"`, { cwd: dir, stdio: 'pipe' });
```

A filename containing a double quote closes the quoting early, and the rest of the name is parsed as shell syntax. Staging a file named

```
a"b$(touch pwned).txt
```

runs the command substitution. The path arrives as `tool_input.file_path` and is passed through unescaped.

The exposure is narrow — the path comes from the agent's own Edit/Write call — but the file itself does not have to be trusted. Checking out a branch, unpacking an archive, or cloning a repo is enough to put an adversarial filename on disk, and `auto-stage` then runs on it silently on every edit.

## The fix

`execFileSync` passes the path as an argv element, so no shell parses it. `--` stops a filename with a leading dash from being read as a git option.

```js
execFileSync('git', ['add', '--', filePath], { cwd: dir, stdio: 'pipe' });
```

`isInGitRepo()` was left alone: its command is a constant, and the path only reaches it as `cwd`.

## Tests

Two cases added to `Unit: stageFile()`:

- **shell metacharacters** — asserts the substitution does not run and the literal filename is staged. Uses `git diff --cached --name-only -z`, since git escapes quotes in the non-`-z` output.
- **leading dash** — covers the `--` guard.

The first test fails against the current implementation and passes with the fix. Full suite: 1167 passing, 0 failing on Node 22.16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
