### PR TITLE
feat: case-insensitive filesystem guard (idea: @yurukusa)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![GitHub stars](https://img.shields.io/github/stars/karanb192/claude-code-hooks?style=social)](https://github.com/karanb192/claude-code-hooks)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![CI](https://github.com/karanb192/claude-code-hooks/actions/workflows/test.yml/badge.svg)](https://github.com/karanb192/claude-code-hooks/actions/workflows/test.yml)
-[![Tests](https://img.shields.io/badge/tests-1165%20passing-brightgreen)](https://github.com/karanb192/claude-code-hooks/actions/workflows/test.yml)
+[![Tests](https://img.shields.io/badge/tests-1216%20passing-brightgreen)](https://github.com/karanb192/claude-code-hooks/actions/workflows/test.yml)
 
 **🌐 [Live site & catalog](https://karanb192.github.io/claude-code-hooks/)**
 
@@ -71,6 +71,7 @@ Runs **before** Claude executes a tool. Can block or modify the operation.
 | [protect-secrets](hook-scripts/pre-tool-use/protect-secrets.js)                   | `Read\|Edit\|Write\|Bash` | Prevents reading/modifying/exfiltrating sensitive files          |
 | [git-safety](hook-scripts/pre-tool-use/git-safety.js)                             | `Bash`                    | Branch-aware git guardrails + destructive gh CLI protection      |
 | [protect-tests](hook-scripts/pre-tool-use/protect-tests.js)                       | `Bash\|Edit\|MultiEdit\|Write` | Stops "fake green": blocks deleting, renaming-away, or skip/xfail-disabling tests |
+| [case-insensitive-guard](hook-scripts/pre-tool-use/case-insensitive-guard.js)     | `Bash`                    | Stops `rm -rf content` destroying `Content` on case-insensitive filesystems (APFS/exFAT/NTFS) — resolves real targets through `cd` chains and quotes |
 
 ### Post-Tool-Use
 
@@ -192,7 +193,7 @@ const SAFETY_LEVEL = "strict"; // or 'critical', 'high'
 
 ### 🙋 Ask mode (prompt instead of block)
 
-`block-dangerous-commands` and `protect-secrets` can **ask** instead of denying outright. When ask mode is on for a level, matching operations return `permissionDecision: "ask"` — Claude Code shows the reason and lets you approve or reject, instead of hard-blocking.
+`block-dangerous-commands`, `protect-secrets`, and `case-insensitive-guard` can **ask** instead of denying outright. When ask mode is on for a level, matching operations return `permissionDecision: "ask"` — Claude Code shows the reason and lets you approve or reject, instead of hard-blocking.
 
 Enable per level via environment variables (the literal string `true`; anything else means deny):
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![GitHub stars](https://img.shields.io/github/stars/karanb192/claude-code-hooks?style=social)](https://github.com/karanb192/claude-code-hooks)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![CI](https://github.com/karanb192/claude-code-hooks/actions/workflows/test.yml/badge.svg)](https://github.com/karanb192/claude-code-hooks/actions/workflows/test.yml)
-[![Tests](https://img.shields.io/badge/tests-1216%20passing-brightgreen)](https://github.com/karanb192/claude-code-hooks/actions/workflows/test.yml)
+[![Tests](https://img.shields.io/badge/tests-1238%20passing-brightgreen)](https://github.com/karanb192/claude-code-hooks/actions/workflows/test.yml)
 
 **🌐 [Live site & catalog](https://karanb192.github.io/claude-code-hooks/)**
 

--- a/hook-scripts/pre-tool-use/case-insensitive-guard.js
+++ b/hook-scripts/pre-tool-use/case-insensitive-guard.js
@@ -10,11 +10,16 @@
  * Idea credit: @yurukusa (https://github.com/karanb192/claude-code-hooks/pull/8)
  *
  * Covered commands: rm, rmdir, mv, mkdir, touch, and `find <path> … -delete`
- * (also `find … -exec rm/unlink`). Directory context is tracked across `cd`
- * and `pushd`, honoring whether each one actually succeeds (the target dir
- * must exist), the connector that follows (`&&` runs the next command only on
- * success, `||` only on failure, `;`/newline/`|` regardless), and subshell
- * `( … )` grouping.
+ * (also `find … -exec rm/unlink`). Directory context is modeled as a set of
+ * candidate cwds plus the last command's exit status: `cd`/`pushd` move it
+ * (honoring whether the target directory exists — including directories a
+ * `mkdir` earlier in the same command line would create), `popd` restores the
+ * matching `pushd`'s directory, a subshell `( … )` restores the outer cwd at
+ * `)`, and connectors gate execution (`&&` runs only after success, `||` only
+ * after failure, `;`/newline/`|`/`&` regardless — with `cd` in a background
+ * (`&`) or pipeline (`|`) position not moving the parent shell). Heredoc
+ * bodies are stripped before analysis, and wrapper prefixes (`nohup`, `exec`,
+ * `command`, `env`, `sudo`, …) are peeled off.
  *
  * SAFETY_LEVEL: 'critical' | 'high' | 'strict'
  *   critical - recursive `rm -r/-rf` (and `find -delete`) onto a case-variant
@@ -37,12 +42,16 @@
  * - Exact-case targets: `rm -rf Content` when `Content` exists as typed is an
  *   intentional delete, not a collision.
  * - A case-only rename (`mv readme.md README.md`) is the CANONICAL fix for a
- *   miscapitalized name — allowed, not blocked.
+ *   miscapitalized name — allowed, not blocked. `mv -t DIR`/`--target-directory`
+ *   moves INTO a directory (contents preserved) — allowed.
  * - Plain `rm` (no -r/-d) of a case-variant DIRECTORY: `rm` refuses to remove
  *   a directory, so nothing is destroyed → allowed.
- * - When the connector semantics leave the run-directory ambiguous, every
- *   candidate directory is checked (fail-closed): a rare over-block is
- *   preferred to a silent data-loss miss.
+ * - Heredoc bodies (`cat <<EOF … EOF`) are document text, not commands.
+ * - Quoted `~` is a literal path character to the shell, so it is not
+ *   tilde-expanded here either.
+ * - When the semantics leave the run-directory ambiguous, every candidate
+ *   directory is checked (fail-closed): a rare over-block is preferred to a
+ *   silent data-loss miss.
  * - No probe files: case-insensitivity is proven by the collision itself —
  *   the typed name is absent from readdir() yet the path still exists.
  *
@@ -87,9 +96,52 @@ function log(entry) {
 
 // ─── shell-aware parsing ─────────────────────────────────────────────────────
 
+// Remove heredoc bodies (`<<EOF … EOF`) so document text is never analyzed as
+// commands. Honors quoted delimiters, `<<-` tab stripping, and multiple
+// heredocs queued on one line. A purely numeric "delimiter" is treated as
+// arithmetic (`$((1<<2))`), not a heredoc.
+function stripHeredocs(command) {
+  let out = '', i = 0, quote = null;
+  const pending = []; // delimiters whose bodies start at the next newline
+  while (i < command.length) {
+    const c = command[i];
+    if (quote) {
+      out += c;
+      if (c === quote && command[i - 1] !== '\\') quote = null;
+      i++; continue;
+    }
+    if (c === "'" || c === '"') { quote = c; out += c; i++; continue; }
+    if (c === '<' && command[i + 1] === '<' && command[i + 2] !== '<' && command[i - 1] !== '<') {
+      let j = i + 2;
+      if (command[j] === '-') j++;
+      while (command[j] === ' ' || command[j] === '\t') j++;
+      let q = null;
+      if (command[j] === "'" || command[j] === '"') { q = command[j]; j++; }
+      let delim = '';
+      while (j < command.length && /[^\s'"();&|<>]/.test(command[j])) { delim += command[j]; j++; }
+      if (q && command[j] === q) j++;
+      if (delim && !/^\d+$/.test(delim)) { pending.push(delim); out += ' '; i = j; continue; }
+      out += c; i++; continue;
+    }
+    if (c === '\n' && pending.length) {
+      out += '\n'; i++;
+      while (pending.length && i < command.length) {
+        let eol = command.indexOf('\n', i);
+        if (eol === -1) eol = command.length;
+        if (command.slice(i, eol).replace(/^\t+/, '') === pending[0]) pending.shift();
+        i = eol + 1;
+      }
+      continue;
+    }
+    out += c; i++;
+  }
+  return out;
+}
+
 // Split a command line into { text, connector } segments, where connector is
 // the operator that PRECEDES the segment (null for the first). Operators inside
-// single/double quotes are ignored.
+// single/double quotes are ignored. A single `&` (background) is a separator
+// too — the command after it still runs; `&>`, `>&`, `<&` redirects are not.
 function splitSegments(command) {
   const segments = [];
   let cur = '', quote = null, connector = null;
@@ -108,6 +160,7 @@ function splitSegments(command) {
     }
     if (c === "'" || c === '"') { quote = c; cur += c; continue; }
     if (c === '&' && command[i + 1] === '&') { push('&&'); i++; continue; }
+    if (c === '&' && command[i + 1] !== '>' && command[i - 1] !== '>' && command[i - 1] !== '<') { push('&'); continue; }
     if (c === '|' && command[i + 1] === '|') { push('||'); i++; continue; }
     if (c === ';') { push(';'); continue; }
     if (c === '|') { push('|'); continue; }
@@ -119,7 +172,8 @@ function splitSegments(command) {
 }
 
 // Tokenize one segment on whitespace, respecting quotes. Each token records
-// whether any part was quoted (quoted globs are literal to the shell).
+// whether any part was quoted (quoted globs are literal to the shell). Unquoted
+// `(` / `)` are shell operators and become standalone tokens even unspaced.
 function tokenize(segment) {
   const tokens = [];
   let text = '', quoted = false, quote = null, started = false;
@@ -131,6 +185,7 @@ function tokenize(segment) {
       continue;
     }
     if (c === "'" || c === '"') { quote = c; quoted = true; started = true; continue; }
+    if (c === '(' || c === ')') { push(); tokens.push({ text: c, quoted: false }); continue; }
     if (/\s/.test(c)) { push(); continue; }
     if (c === '\\' && i + 1 < segment.length) { text += segment[i + 1]; started = true; i++; continue; }
     text += c; started = true;
@@ -140,6 +195,8 @@ function tokenize(segment) {
 }
 
 const SHELL_KEYWORDS = new Set(['if', 'then', 'else', 'elif', 'fi', 'for', 'while', 'until', 'do', 'done', 'case', 'esac', 'function', '{', '}']);
+// Wrappers that just run their argument as the real command.
+const PREFIX_CMDS = new Set(['command', 'builtin', 'exec', 'time', 'nohup', 'env', 'sudo']);
 
 // Strip subshell parens, leading env assignments (FOO=bar) and `sudo`.
 function commandTokens(tokens) {
@@ -156,11 +213,13 @@ function commandTokens(tokens) {
 function hasUnresolvable(text) { return /[$`]/.test(text); }
 function hasGlob(tok) { return !tok.quoted && /[*?[]/.test(tok.text); }
 
-function resolveTarget(text, cwd) {
+function resolveTarget(text, cwd, quoted = false) {
   if (hasUnresolvable(text)) return null;
   let t = text;
-  if (t === '~') t = os.homedir();
-  else if (t.startsWith('~/')) t = path.join(os.homedir(), t.slice(2));
+  if (!quoted) { // a quoted ~ is a literal character to the shell
+    if (t === '~') t = os.homedir();
+    else if (t.startsWith('~/')) t = path.join(os.homedir(), t.slice(2));
+  }
   if (!path.isAbsolute(t) && !cwd) return null;
   return path.resolve(cwd || '/', t);
 }
@@ -205,62 +264,122 @@ function splitArgs(tokens) {
   return { flags, operands };
 }
 
-// Candidate directories a command might run in, given a pending cd/pushd and
-// the connector that follows it. Arrays are concrete dirs; null means unknown
-// (relative targets can't be resolved); [] means the command cannot run.
-function nextCwds(prevCd, connector) {
-  const { before, after, exists } = prevCd;
-  const succeeded = exists === true, failed = exists === false;
+// Analyze one full command string. Returns the first destructive collision:
+// { level, cmd, typed, actual, parent } — or null when nothing provable.
+//
+// State model: `shell` is the set of candidate cwds the shell could be in
+// (null = unknown), `lastStatus` is the last command's exit status
+// ('ok' | 'fail' | 'unknown') and gates `&&` / `||` segments. `dirStack`
+// mirrors pushd/popd; `subStack` snapshots the cwd at `(` and restores it at
+// `)`; `createdDirs` remembers `mkdir` targets from earlier in the same line
+// so a following `cd` into a not-yet-existing directory is still tracked.
+function analyzeCommand(command, cwd, fsx = realFsx) {
+  if (typeof command !== 'string' || !command.trim()) return null;
+  let shell = cwd && path.isAbsolute(cwd) ? [cwd] : null;
+  let lastStatus = 'ok';
+  const dirStack = [], subStack = [], createdDirs = new Set();
+
+  // Merge candidate sets; null means "no further information", so the known
+  // side wins (its candidates still get checked — fail-closed).
   const union = (a, b) => {
-    if (a === null) return b === null ? null : b;
+    if (a === null) return b;
     if (b === null) return a;
     return [...new Set([...a, ...b])];
   };
-  if (connector === '&&') return failed ? [] : (after ? [after] : null);
-  if (connector === '||') return succeeded ? [] : before;
-  // ; | \n : next command runs regardless of the cd result
-  if (succeeded) return after ? [after] : null;
-  if (failed) return before;
-  return union(before, after);
-}
 
-// Analyze one full command string. Returns the first destructive collision:
-// { level, cmd, typed, actual, parent } — or null when nothing provable.
-function analyzeCommand(command, cwd, fsx = realFsx) {
-  if (typeof command !== 'string' || !command.trim()) return null;
-  let cwds = cwd && path.isAbsolute(cwd) ? [cwd] : null;
-  let prevCd = null;
+  const segs = splitSegments(stripHeredocs(command));
+  for (let si = 0; si < segs.length; si++) {
+    const { text, connector } = segs[si];
+    const nextConn = si + 1 < segs.length ? segs[si + 1].connector : null;
 
-  for (const { text, connector } of splitSegments(command)) {
-    if (prevCd) { cwds = nextCwds(prevCd, connector); prevCd = null; }
-    if (/\$\(|`/.test(text)) { continue; } // command substitution: not resolvable
+    const runs = connector === '&&' ? (lastStatus === 'ok' ? true : lastStatus === 'fail' ? false : 'maybe')
+               : connector === '||' ? (lastStatus === 'fail' ? true : lastStatus === 'ok' ? false : 'maybe')
+               : true;
+    if (runs === false) continue; // this segment cannot execute
 
-    const tokens = commandTokens(tokenize(text));
-    if (!tokens.length) continue;
+    if (/\$\(|`/.test(text)) { lastStatus = 'unknown'; continue; } // command substitution: not resolvable
+
+    const raw = tokenize(text);
+    let lo = 0, hi = raw.length;
+    while (lo < hi && raw[lo].text === '(') { subStack.push(shell); lo++; }
+    let closers = 0;
+    while (hi > lo && raw[hi - 1].text === ')') { closers++; hi--; }
+    const closeSubshells = () => {
+      while (closers-- > 0) {
+        if (subStack.length) shell = subStack.pop(); // `( … )` never moves the parent
+        lastStatus = 'unknown';
+      }
+    };
+
+    let tokens = commandTokens(raw.slice(lo, hi));
+    let negated = false;
+    for (let guard = 0; guard < raw.length && tokens.length; guard++) {
+      const t = tokens[0].text;
+      if (SHELL_KEYWORDS.has(t) || t === '!') {
+        if (t === '!') negated = true;
+        tokens = tokens.slice(1);
+      } else if (PREFIX_CMDS.has(t)) {
+        tokens = tokens.slice(1);
+        while (tokens.length && /^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[0].text)) tokens = tokens.slice(1);
+        while (tokens.length && tokens[0].text.startsWith('-')) tokens = tokens.slice(1);
+      } else break;
+    }
+    if (!tokens.length) { closeSubshells(); continue; }
     const cmd = path.basename(tokens[0].text);
-    if (SHELL_KEYWORDS.has(cmd)) continue;
 
-    // Directory tracking: cd / pushd move; popd / bare pushd → unknown.
+    // A `cd` followed by `&` (background) or `|` (pipeline) runs in a subshell
+    // and never moves the parent — keep the old cwd, add the new fail-closed.
+    const detached = nextConn === '&' || nextConn === '|';
+
     if (cmd === 'cd' || cmd === 'pushd') {
+      const before = shell;
       const target = tokens[1];
-      if (cmd === 'cd' && !target) { prevCd = { before: cwds, after: os.homedir(), exists: true }; continue; }
-      if (!target || hasUnresolvable(target.text) || target.text === '-') { prevCd = { before: cwds, after: null, exists: undefined }; continue; }
-      const dirs = cwds === null ? [null] : cwds;
-      const after = resolveTarget(target.text, dirs[0]);
-      const exists = after ? fsx.isDirectory(after) : undefined;
-      prevCd = { before: cwds, after, exists };
+      let afters = null, exists;
+      if (cmd === 'cd' && !target) { afters = [os.homedir()]; exists = true; }
+      else if (!target || hasUnresolvable(target.text) || target.text === '-') { afters = null; exists = undefined; }
+      else {
+        const dirs = shell === null ? [null] : shell;
+        afters = [...new Set(dirs.map(d => resolveTarget(target.text, d, target.quoted)).filter(Boolean))];
+        if (!afters.length) afters = null;
+        if (afters === null) exists = undefined;
+        else {
+          const ex = afters.map(a => fsx.isDirectory(a) ? true : createdDirs.has(a) ? undefined : false);
+          exists = ex.every(v => v === true) ? true : ex.every(v => v === false) ? false : undefined;
+        }
+      }
+      if (cmd === 'pushd') dirStack.push(before);
+      let newShell, newStatus;
+      if (afters === null) { newShell = null; newStatus = 'unknown'; }
+      else if (exists === true) { newShell = afters; newStatus = 'ok'; }
+      else if (exists === false) { newShell = before; newStatus = 'fail'; }
+      else { newShell = union(before, afters); newStatus = 'unknown'; }
+      if (detached) { shell = union(before, newShell); lastStatus = 'ok'; }
+      else if (runs === 'maybe') { shell = union(before, newShell); lastStatus = 'unknown'; }
+      else { shell = newShell; lastStatus = negated ? 'unknown' : newStatus; }
+      closeSubshells();
       continue;
     }
-    if (cmd === 'popd') { cwds = null; continue; }
+    if (cmd === 'popd') {
+      if (dirStack.length) {
+        const popped = dirStack.pop();
+        shell = (runs === true && !detached) ? popped : union(popped, shell);
+      } // popd on an empty stack fails: cwd unchanged
+      lastStatus = 'unknown';
+      closeSubshells();
+      continue;
+    }
 
-    if (!['rm', 'rmdir', 'mv', 'mkdir', 'touch', 'find'].includes(cmd)) continue;
-    if (Array.isArray(cwds) && cwds.length === 0) continue; // command cannot run
+    if (!['rm', 'rmdir', 'mv', 'mkdir', 'touch', 'find'].includes(cmd)) {
+      lastStatus = 'unknown';
+      closeSubshells();
+      continue;
+    }
 
-    const dirs = cwds === null ? [null] : cwds;
+    const dirs = shell === null ? [null] : shell;
     const check = (tok) => {
       if (hasGlob(tok) || hasUnresolvable(tok.text)) return null;
       for (const d of dirs) {
-        const resolved = resolveTarget(tok.text, d);
+        const resolved = resolveTarget(tok.text, d, tok.quoted);
         if (!resolved) continue;
         const hit = findCollision(resolved, fsx);
         if (hit) return hit;
@@ -286,25 +405,37 @@ function analyzeCommand(command, cwd, fsx = realFsx) {
         if (hit) return { level: 'high', cmd: 'rmdir', ...hit };
       }
     } else if (cmd === 'mv' && operands.length >= 2) {
-      const dest = operands[operands.length - 1];
-      // A case-only self-rename (source folds to dest) is the intended fix.
-      const selfRename = operands.slice(0, -1).some((src) => {
-        for (const d of dirs) {
-          const s = resolveTarget(src.text, d), t = resolveTarget(dest.text, d);
-          if (s && t && path.dirname(s) === path.dirname(t) && path.basename(s).toLowerCase() === path.basename(t).toLowerCase()) return true;
+      // `mv -t DIR` / `--target-directory=DIR` moves INTO a directory
+      // (contents preserved) and its last operand is a SOURCE — skip.
+      const intoDir = flags.some(f => /^-[A-Za-z]*t$/.test(f) || f.startsWith('--target-directory'));
+      if (!intoDir) {
+        const dest = operands[operands.length - 1];
+        // A case-only self-rename (source folds to dest) is the intended fix.
+        const selfRename = operands.slice(0, -1).some((src) => {
+          for (const d of dirs) {
+            const s = resolveTarget(src.text, d, src.quoted), t = resolveTarget(dest.text, d, dest.quoted);
+            if (s && t && path.dirname(s) === path.dirname(t) && path.basename(s).toLowerCase() === path.basename(t).toLowerCase()) return true;
+          }
+          return false;
+        });
+        if (!selfRename) {
+          const hit = check(dest);
+          // Overwriting a case-variant FILE clobbers data; moving INTO a
+          // case-variant directory preserves contents.
+          if (hit && !hit.actualIsDir) return { level: 'high', cmd: 'mv', ...hit };
         }
-        return false;
-      });
-      if (!selfRename) {
-        const hit = check(dest);
-        // Overwriting a case-variant FILE clobbers data; moving INTO a
-        // case-variant directory preserves contents.
-        if (hit && !hit.actualIsDir) return { level: 'high', cmd: 'mv', ...hit };
       }
     } else if (cmd === 'mkdir' || cmd === 'touch') {
       for (const tok of operands) {
         const hit = check(tok);
         if (hit) return { level: 'strict', cmd, ...hit };
+      }
+      if (cmd === 'mkdir') {
+        // Remember what this line creates so a later `cd` into it is tracked.
+        for (const tok of operands) for (const d of dirs) {
+          const r = resolveTarget(tok.text, d, tok.quoted);
+          if (r) createdDirs.add(r);
+        }
       }
     } else if (cmd === 'find') {
       // `find <paths…> <expression>`: paths are the operands before the first
@@ -324,6 +455,8 @@ function analyzeCommand(command, cwd, fsx = realFsx) {
         }
       }
     }
+    lastStatus = 'unknown';
+    closeSubshells();
   }
   return null;
 }
@@ -371,5 +504,5 @@ async function main() {
 if (require.main === module) {
   main();
 } else {
-  module.exports = { SAFETY_LEVEL, LEVELS, ASK, splitSegments, tokenize, commandTokens, resolveTarget, findCollision, analyzeCommand, checkCommand, realFsx };
+  module.exports = { SAFETY_LEVEL, LEVELS, ASK, stripHeredocs, splitSegments, tokenize, commandTokens, resolveTarget, findCollision, analyzeCommand, checkCommand, realFsx };
 }

--- a/hook-scripts/pre-tool-use/case-insensitive-guard.js
+++ b/hook-scripts/pre-tool-use/case-insensitive-guard.js
@@ -1,0 +1,375 @@
+#!/usr/bin/env node
+/**
+ * Case-Insensitive Filesystem Guard - PreToolUse Hook for Bash
+ * On case-insensitive filesystems (APFS default, exFAT, NTFS), `Content` and
+ * `content` are the same path — so `rm -rf content` silently destroys
+ * `Content` (see anthropics/claude-code#37875). This hook resolves the real
+ * target directory of destructive commands and denies the ones that would hit
+ * a case-variant of what was typed. Logs to: ~/.claude/hooks-logs/
+ *
+ * Idea credit: @yurukusa (https://github.com/karanb192/claude-code-hooks/pull/8)
+ *
+ * Covered commands: rm, rmdir, mv, mkdir, touch, and `find <path> … -delete`
+ * (also `find … -exec rm/unlink`). Directory context is tracked across `cd`
+ * and `pushd`, honoring whether each one actually succeeds (the target dir
+ * must exist), the connector that follows (`&&` runs the next command only on
+ * success, `||` only on failure, `;`/newline/`|` regardless), and subshell
+ * `( … )` grouping.
+ *
+ * SAFETY_LEVEL: 'critical' | 'high' | 'strict'
+ *   critical - recursive `rm -r/-rf` (and `find -delete`) onto a case-variant
+ *   high     - + non-recursive deletes that really remove something
+ *              (`rm` of a case-variant FILE, `rm -d`/`rmdir` of a case-variant
+ *              dir, `mv` overwriting a case-variant FILE)
+ *   strict   - + mkdir/touch onto an existing case-variant (usually a no-op,
+ *              but often a sign the agent has the wrong name in mind)
+ *
+ * Ask mode (opt-in, per level): set HOOK_ASK_CRITICAL / HOOK_ASK_HIGH /
+ * HOOK_ASK_STRICT to the literal string "true" to prompt instead of deny.
+ *
+ * Design notes (what is deliberately NOT flagged):
+ * - Glob targets (`rm -rf Cont*`): the shell expands globs against real
+ *   directory entries with case-SENSITIVE matching (bash default), so a
+ *   miscased glob matches nothing and cannot case-collide. (Limitation:
+ *   `shopt -s nocaseglob` defeats this; not modeled.)
+ * - `$VAR`, `$(…)`, backticks: not statically resolvable → conservatively
+ *   allowed rather than guessed at.
+ * - Exact-case targets: `rm -rf Content` when `Content` exists as typed is an
+ *   intentional delete, not a collision.
+ * - A case-only rename (`mv readme.md README.md`) is the CANONICAL fix for a
+ *   miscapitalized name — allowed, not blocked.
+ * - Plain `rm` (no -r/-d) of a case-variant DIRECTORY: `rm` refuses to remove
+ *   a directory, so nothing is destroyed → allowed.
+ * - When the connector semantics leave the run-directory ambiguous, every
+ *   candidate directory is checked (fail-closed): a rare over-block is
+ *   preferred to a silent data-loss miss.
+ * - No probe files: case-insensitivity is proven by the collision itself —
+ *   the typed name is absent from readdir() yet the path still exists.
+ *
+ * Setup in .claude/settings.json:
+ * {
+ *   "hooks": {
+ *     "PreToolUse": [{
+ *       "matcher": "Bash",
+ *       "hooks": [{ "type": "command", "command": "node /path/to/case-insensitive-guard.js" }]
+ *     }]
+ *   }
+ * }
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const SAFETY_LEVEL = 'high';
+
+const LEVELS = { critical: 1, high: 2, strict: 3 };
+const EMOJIS = { critical: '🚨', high: '⛔', strict: '⚠️' };
+
+// Ask mode per level: if true, prompts the user instead of blocking outright.
+// Env overrides: HOOK_ASK_CRITICAL, HOOK_ASK_HIGH, HOOK_ASK_STRICT
+const envBool = (key, fallback) => key in process.env ? process.env[key] === 'true' : fallback;
+const ASK = {
+  critical: envBool('HOOK_ASK_CRITICAL', false),
+  high:     envBool('HOOK_ASK_HIGH', false),
+  strict:   envBool('HOOK_ASK_STRICT', false),
+};
+
+const LOG_DIR = path.join(process.env.HOME || os.homedir(), '.claude', 'hooks-logs');
+
+function log(entry) {
+  try {
+    fs.mkdirSync(LOG_DIR, { recursive: true });
+    const file = path.join(LOG_DIR, `${new Date().toISOString().slice(0, 10)}.jsonl`);
+    fs.appendFileSync(file, JSON.stringify({ ts: new Date().toISOString(), hook: 'case-insensitive-guard', ...entry }) + '\n');
+  } catch { /* logging must never break the hook */ }
+}
+
+// ─── shell-aware parsing ─────────────────────────────────────────────────────
+
+// Split a command line into { text, connector } segments, where connector is
+// the operator that PRECEDES the segment (null for the first). Operators inside
+// single/double quotes are ignored.
+function splitSegments(command) {
+  const segments = [];
+  let cur = '', quote = null, connector = null;
+  const push = (nextConnector) => {
+    const text = cur.trim();
+    if (text) segments.push({ text, connector });
+    cur = '';
+    connector = nextConnector;
+  };
+  for (let i = 0; i < command.length; i++) {
+    const c = command[i];
+    if (quote) {
+      cur += c;
+      if (c === quote && command[i - 1] !== '\\') quote = null;
+      continue;
+    }
+    if (c === "'" || c === '"') { quote = c; cur += c; continue; }
+    if (c === '&' && command[i + 1] === '&') { push('&&'); i++; continue; }
+    if (c === '|' && command[i + 1] === '|') { push('||'); i++; continue; }
+    if (c === ';') { push(';'); continue; }
+    if (c === '|') { push('|'); continue; }
+    if (c === '\n') { push('\n'); continue; }
+    cur += c;
+  }
+  push(null);
+  return segments;
+}
+
+// Tokenize one segment on whitespace, respecting quotes. Each token records
+// whether any part was quoted (quoted globs are literal to the shell).
+function tokenize(segment) {
+  const tokens = [];
+  let text = '', quoted = false, quote = null, started = false;
+  const push = () => { if (started) tokens.push({ text, quoted }); text = ''; quoted = false; started = false; };
+  for (let i = 0; i < segment.length; i++) {
+    const c = segment[i];
+    if (quote) {
+      if (c === quote) { quote = null; } else { text += c; }
+      continue;
+    }
+    if (c === "'" || c === '"') { quote = c; quoted = true; started = true; continue; }
+    if (/\s/.test(c)) { push(); continue; }
+    if (c === '\\' && i + 1 < segment.length) { text += segment[i + 1]; started = true; i++; continue; }
+    text += c; started = true;
+  }
+  push();
+  return tokens;
+}
+
+const SHELL_KEYWORDS = new Set(['if', 'then', 'else', 'elif', 'fi', 'for', 'while', 'until', 'do', 'done', 'case', 'esac', 'function', '{', '}']);
+
+// Strip subshell parens, leading env assignments (FOO=bar) and `sudo`.
+function commandTokens(tokens) {
+  let toks = tokens.filter(t => t.text !== '(' && t.text !== ')');
+  let i = 0;
+  while (i < toks.length && /^[A-Za-z_][A-Za-z0-9_]*=/.test(toks[i].text)) i++;
+  if (i < toks.length && toks[i].text === 'sudo') {
+    i++;
+    while (i < toks.length && toks[i].text.startsWith('-')) i++;
+  }
+  return toks.slice(i);
+}
+
+function hasUnresolvable(text) { return /[$`]/.test(text); }
+function hasGlob(tok) { return !tok.quoted && /[*?[]/.test(tok.text); }
+
+function resolveTarget(text, cwd) {
+  if (hasUnresolvable(text)) return null;
+  let t = text;
+  if (t === '~') t = os.homedir();
+  else if (t.startsWith('~/')) t = path.join(os.homedir(), t.slice(2));
+  if (!path.isAbsolute(t) && !cwd) return null;
+  return path.resolve(cwd || '/', t);
+}
+
+// ─── collision analysis ──────────────────────────────────────────────────────
+
+// Real filesystem operations, injectable for hermetic cross-platform tests.
+const realFsx = {
+  listDir(dir) { try { return fs.readdirSync(dir); } catch { return null; } },
+  pathExists(p) { try { return fs.existsSync(p); } catch { return false; } },
+  isDirectory(p) { try { return fs.statSync(p).isDirectory(); } catch { return false; } },
+};
+
+// A collision exists when the typed basename is NOT an on-disk entry of the
+// parent, yet a differently-cased entry is — and the typed path still exists
+// (proving the volume folds case, no probe file needed).
+function findCollision(resolved, fsx) {
+  const parent = path.dirname(resolved);
+  const base = path.basename(resolved);
+  if (!base || base === '.' || base === '..') return null;
+  const entries = fsx.listDir(parent);
+  if (!entries || entries.includes(base)) return null;
+  const variant = entries.find(e => e.toLowerCase() === base.toLowerCase());
+  if (!variant) return null;
+  if (!fsx.pathExists(resolved)) return null; // case-sensitive volume: harmless miss
+  const isDir = fsx.isDirectory(path.join(parent, variant));
+  return { typed: base, actual: variant, parent, actualIsDir: isDir };
+}
+
+const RECURSIVE_FLAG = (f) => /^-[A-Za-z]*[rR]/.test(f) || f === '--recursive';
+const DIR_FLAG = (f) => /^-[A-Za-z]*d/.test(f) || f === '--dir';
+
+// Split flags from operands for a token list (POSIX `--` ends option parsing).
+function splitArgs(tokens) {
+  const flags = [], operands = [];
+  let sawDoubleDash = false;
+  for (const t of tokens) {
+    if (!sawDoubleDash && t.text === '--' && !t.quoted) { sawDoubleDash = true; continue; }
+    if (!sawDoubleDash && t.text.startsWith('-') && !t.quoted && t.text !== '-') { flags.push(t.text); continue; }
+    operands.push(t);
+  }
+  return { flags, operands };
+}
+
+// Candidate directories a command might run in, given a pending cd/pushd and
+// the connector that follows it. Arrays are concrete dirs; null means unknown
+// (relative targets can't be resolved); [] means the command cannot run.
+function nextCwds(prevCd, connector) {
+  const { before, after, exists } = prevCd;
+  const succeeded = exists === true, failed = exists === false;
+  const union = (a, b) => {
+    if (a === null) return b === null ? null : b;
+    if (b === null) return a;
+    return [...new Set([...a, ...b])];
+  };
+  if (connector === '&&') return failed ? [] : (after ? [after] : null);
+  if (connector === '||') return succeeded ? [] : before;
+  // ; | \n : next command runs regardless of the cd result
+  if (succeeded) return after ? [after] : null;
+  if (failed) return before;
+  return union(before, after);
+}
+
+// Analyze one full command string. Returns the first destructive collision:
+// { level, cmd, typed, actual, parent } — or null when nothing provable.
+function analyzeCommand(command, cwd, fsx = realFsx) {
+  if (typeof command !== 'string' || !command.trim()) return null;
+  let cwds = cwd && path.isAbsolute(cwd) ? [cwd] : null;
+  let prevCd = null;
+
+  for (const { text, connector } of splitSegments(command)) {
+    if (prevCd) { cwds = nextCwds(prevCd, connector); prevCd = null; }
+    if (/\$\(|`/.test(text)) { continue; } // command substitution: not resolvable
+
+    const tokens = commandTokens(tokenize(text));
+    if (!tokens.length) continue;
+    const cmd = path.basename(tokens[0].text);
+    if (SHELL_KEYWORDS.has(cmd)) continue;
+
+    // Directory tracking: cd / pushd move; popd / bare pushd → unknown.
+    if (cmd === 'cd' || cmd === 'pushd') {
+      const target = tokens[1];
+      if (cmd === 'cd' && !target) { prevCd = { before: cwds, after: os.homedir(), exists: true }; continue; }
+      if (!target || hasUnresolvable(target.text) || target.text === '-') { prevCd = { before: cwds, after: null, exists: undefined }; continue; }
+      const dirs = cwds === null ? [null] : cwds;
+      const after = resolveTarget(target.text, dirs[0]);
+      const exists = after ? fsx.isDirectory(after) : undefined;
+      prevCd = { before: cwds, after, exists };
+      continue;
+    }
+    if (cmd === 'popd') { cwds = null; continue; }
+
+    if (!['rm', 'rmdir', 'mv', 'mkdir', 'touch', 'find'].includes(cmd)) continue;
+    if (Array.isArray(cwds) && cwds.length === 0) continue; // command cannot run
+
+    const dirs = cwds === null ? [null] : cwds;
+    const check = (tok) => {
+      if (hasGlob(tok) || hasUnresolvable(tok.text)) return null;
+      for (const d of dirs) {
+        const resolved = resolveTarget(tok.text, d);
+        if (!resolved) continue;
+        const hit = findCollision(resolved, fsx);
+        if (hit) return hit;
+      }
+      return null;
+    };
+
+    const { flags, operands } = splitArgs(tokens.slice(1));
+
+    if (cmd === 'rm') {
+      const recursive = flags.some(RECURSIVE_FLAG);
+      const removesDirs = recursive || flags.some(DIR_FLAG);
+      for (const tok of operands) {
+        const hit = check(tok);
+        if (!hit) continue;
+        // Plain rm cannot remove a directory, so a dir-only collision is a no-op.
+        if (hit.actualIsDir && !removesDirs) continue;
+        return { level: recursive ? 'critical' : 'high', cmd: recursive ? 'rm -r' : 'rm', ...hit };
+      }
+    } else if (cmd === 'rmdir') {
+      for (const tok of operands) {
+        const hit = check(tok);
+        if (hit) return { level: 'high', cmd: 'rmdir', ...hit };
+      }
+    } else if (cmd === 'mv' && operands.length >= 2) {
+      const dest = operands[operands.length - 1];
+      // A case-only self-rename (source folds to dest) is the intended fix.
+      const selfRename = operands.slice(0, -1).some((src) => {
+        for (const d of dirs) {
+          const s = resolveTarget(src.text, d), t = resolveTarget(dest.text, d);
+          if (s && t && path.dirname(s) === path.dirname(t) && path.basename(s).toLowerCase() === path.basename(t).toLowerCase()) return true;
+        }
+        return false;
+      });
+      if (!selfRename) {
+        const hit = check(dest);
+        // Overwriting a case-variant FILE clobbers data; moving INTO a
+        // case-variant directory preserves contents.
+        if (hit && !hit.actualIsDir) return { level: 'high', cmd: 'mv', ...hit };
+      }
+    } else if (cmd === 'mkdir' || cmd === 'touch') {
+      for (const tok of operands) {
+        const hit = check(tok);
+        if (hit) return { level: 'strict', cmd, ...hit };
+      }
+    } else if (cmd === 'find') {
+      // `find <paths…> <expression>`: paths are the operands before the first
+      // predicate (a token starting with '-'). Only destructive if the
+      // expression deletes.
+      const rest = tokens.slice(1);
+      const predicateIdx = rest.findIndex(t => t.text.startsWith('-'));
+      const paths = (predicateIdx === -1 ? rest : rest.slice(0, predicateIdx));
+      const expr = predicateIdx === -1 ? [] : rest.slice(predicateIdx);
+      const deletes = expr.some((t, i) =>
+        t.text === '-delete' ||
+        ((t.text === '-exec' || t.text === '-execdir') && /^(rm|unlink)$/.test(expr[i + 1]?.text || '')));
+      if (deletes) {
+        for (const tok of paths) {
+          const hit = check(tok);
+          if (hit) return { level: 'critical', cmd: 'find -delete', ...hit };
+        }
+      }
+    }
+  }
+  return null;
+}
+
+function checkCommand(command, cwd, safetyLevel = SAFETY_LEVEL, fsx = realFsx) {
+  const hit = analyzeCommand(command, cwd, fsx);
+  if (!hit) return { blocked: false };
+  if (LEVELS[hit.level] > LEVELS[safetyLevel]) return { blocked: false };
+  return { blocked: true, hit };
+}
+
+// ─── hook entrypoint ─────────────────────────────────────────────────────────
+
+async function main() {
+  let input = '';
+  for await (const chunk of process.stdin) input += chunk;
+
+  let data;
+  try {
+    data = JSON.parse(input);
+  } catch {
+    return console.log('{}');
+  }
+  if (data === null || typeof data !== 'object') data = {};
+
+  const { tool_name, tool_input, session_id, cwd, permission_mode } = data;
+  if (tool_name !== 'Bash' || !tool_input?.command) return console.log('{}');
+
+  const result = checkCommand(tool_input.command, cwd);
+  if (!result.blocked) return console.log('{}');
+
+  const { hit } = result;
+  const shouldAsk = ASK[hit.level] === true;
+  const decision = shouldAsk ? 'ask' : 'deny';
+  log({ level: shouldAsk ? 'ASK' : 'BLOCKED', id: 'case-collision', priority: hit.level, decision, cmd: tool_input.command, typed: hit.typed, actual: hit.actual, session_id, cwd, permission_mode });
+  return console.log(JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: decision,
+      permissionDecisionReason: `${EMOJIS[hit.level]} [case-collision] ${hit.cmd} targets '${hit.typed}' but this case-insensitive directory contains '${hit.actual}' — same path on disk, so the differently-cased entry would be hit`,
+    },
+  }));
+}
+
+if (require.main === module) {
+  main();
+} else {
+  module.exports = { SAFETY_LEVEL, LEVELS, ASK, splitSegments, tokenize, commandTokens, resolveTarget, findCollision, analyzeCommand, checkCommand, realFsx };
+}

--- a/hook-scripts/tests/pre-tool-use/case-insensitive-guard.test.js
+++ b/hook-scripts/tests/pre-tool-use/case-insensitive-guard.test.js
@@ -20,6 +20,7 @@ const os = require('node:os');
 const {
   splitSegments,
   tokenize,
+  stripHeredocs,
   analyzeCommand,
   checkCommand,
   LEVELS,
@@ -359,4 +360,104 @@ describe('Integration: real collisions', { skip: !TMP_IS_CASE_INSENSITIVE && 'tm
       const { output } = await runHook(bash('rm -rf Content', d), { HOOK_ASK_CRITICAL: 'true' });
       assert.strictEqual(deny(output), 'ask');
     }));
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Unit: round-2 hardening — shell-state model (background &, subshells,
+// pushd/popd stack, exit-status gating, heredocs, mv -t, quoted ~)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Unit: round-2 hardening — bypasses closed', () => {
+  it('analyzes commands after a background & separator', () => {
+    const hit = analyzeCommand('sleep 1 & rm -rf CONTENT', '/repo', ciFsx());
+    assert.strictEqual(hit?.level, 'critical');
+  });
+  it('does not treat >&/2>&1 redirects as separators', () => {
+    const hit = analyzeCommand('rm -rf CONTENT 2>&1', '/repo', ciFsx());
+    assert.strictEqual(hit?.level, 'critical');
+  });
+  it('restores the pushd directory after popd', () => {
+    const hit = analyzeCommand('pushd src; touch a.txt; popd; rm -rf CONTENT', '/repo', ciFsx());
+    assert.strictEqual(hit?.level, 'critical');
+  });
+  it('keeps tracking through a failed-cd && chain followed by ;', () => {
+    const hit = analyzeCommand('cd missing && cd src; rm -rf CONTENT', '/repo', ciFsx());
+    assert.strictEqual(hit?.level, 'critical');
+  });
+  it('tracks cd into a directory mkdir creates on the same line', () => {
+    const hit = analyzeCommand('mkdir build && cd build && rm -rf ../CONTENT', '/repo', ciFsx());
+    assert.strictEqual(hit?.level, 'critical');
+  });
+  it('a cd inside ( … ) does not leak past the closing paren', () => {
+    const hit = analyzeCommand('( cd src ); rm -rf CONTENT', '/repo', ciFsx());
+    assert.strictEqual(hit?.level, 'critical');
+  });
+  it('handles unspaced subshell parens', () => {
+    const hit = analyzeCommand('(cd src && ls); rm -rf CONTENT', '/repo', ciFsx());
+    assert.strictEqual(hit?.level, 'critical');
+  });
+  it('a cd in a pipeline does not move the parent shell', () => {
+    const hit = analyzeCommand('cd src | cat; rm -rf CONTENT', '/repo', ciFsx());
+    assert.strictEqual(hit?.level, 'critical');
+  });
+  it('peels wrapper prefixes: nohup … &', () => {
+    const hit = analyzeCommand('nohup rm -rf CONTENT &', '/repo', ciFsx());
+    assert.strictEqual(hit?.level, 'critical');
+  });
+  it('peels wrapper prefixes: exec', () => {
+    const hit = analyzeCommand('exec rm -rf CONTENT', '/repo', ciFsx());
+    assert.strictEqual(hit?.level, 'critical');
+  });
+  it('! negation makes the gate uncertain, so the follow-up is still checked', () => {
+    const hit = analyzeCommand('! cd missing && rm -rf CONTENT', '/repo', ciFsx());
+    assert.strictEqual(hit?.level, 'critical');
+  });
+  it('a live command after a heredoc is still analyzed', () => {
+    const hit = analyzeCommand('cat <<EOF\nhello\nEOF\nrm -rf CONTENT', '/repo', ciFsx());
+    assert.strictEqual(hit?.level, 'critical');
+  });
+  it('numeric << is arithmetic, not a heredoc — following lines stay live', () => {
+    const hit = analyzeCommand('echo $((1<<2))\nrm -rf CONTENT', '/repo', ciFsx());
+    assert.strictEqual(hit?.level, 'critical');
+  });
+});
+
+describe('Unit: round-2 hardening — false positives removed', () => {
+  it('mv -t DIR treats operands as sources, not a destination', () => {
+    assert.strictEqual(analyzeCommand('mv -t src Notes.txt', '/repo', ciFsx()), null);
+  });
+  it('mv --target-directory=DIR is a move into a directory', () => {
+    assert.strictEqual(analyzeCommand('mv --target-directory=src Notes.txt', '/repo', ciFsx()), null);
+  });
+  it('heredoc bodies are document text, not commands', () => {
+    assert.strictEqual(analyzeCommand('cat <<EOF > out.txt\nrm -rf CONTENT\nEOF', '/repo', ciFsx()), null);
+  });
+  it('quoted heredoc delimiters work too', () => {
+    assert.strictEqual(analyzeCommand("cat <<'DOC'\nrm -rf CONTENT\nDOC", '/repo', ciFsx()), null);
+  });
+  it('a quoted ~ is a literal path, not the home directory', () => {
+    assert.strictEqual(analyzeCommand("rm -rf '~/CONTENT'", '/repo', ciFsx()), null);
+  });
+});
+
+describe('Unit: stripHeredocs()', () => {
+  it('removes the body but keeps commands after the terminator', () => {
+    const out = stripHeredocs('cat <<EOF\nrm -rf x\nEOF\necho done');
+    assert.ok(!out.includes('rm -rf x'));
+    assert.ok(out.includes('echo done'));
+  });
+  it('handles <<- with tab-indented terminators', () => {
+    const out = stripHeredocs('cat <<-END\nrm -rf x\n\tEND\necho after');
+    assert.ok(!out.includes('rm -rf x'));
+    assert.ok(out.includes('echo after'));
+  });
+  it('queues multiple heredocs on one line in order', () => {
+    const out = stripHeredocs('diff <(cat) - <<A <<B\nbody a\nA\nbody b\nB\necho tail');
+    assert.ok(!out.includes('body a') && !out.includes('body b'));
+    assert.ok(out.includes('echo tail'));
+  });
+  it('leaves <<< here-strings and quoted << alone', () => {
+    assert.ok(stripHeredocs('grep x <<< "input"').includes('<<<'));
+    assert.ok(stripHeredocs('echo "a << b"').includes('a << b'));
+  });
 });

--- a/hook-scripts/tests/pre-tool-use/case-insensitive-guard.test.js
+++ b/hook-scripts/tests/pre-tool-use/case-insensitive-guard.test.js
@@ -1,0 +1,362 @@
+#!/usr/bin/env node
+/**
+ * Tests for case-insensitive-guard.js
+ *
+ * Run: node --test hook-scripts/tests/pre-tool-use/case-insensitive-guard.test.js
+ * Or:  npm test
+ *
+ * Unit tests inject a fake filesystem, so collision logic runs deterministically
+ * on every platform (Linux CI included). Integration tests that need a REAL
+ * case-insensitive volume self-skip where the tmpdir is case-sensitive.
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { spawn } = require('node:child_process');
+const path = require('node:path');
+const fs = require('node:fs');
+const os = require('node:os');
+
+const {
+  splitSegments,
+  tokenize,
+  analyzeCommand,
+  checkCommand,
+  LEVELS,
+  ASK,
+} = require('../../pre-tool-use/case-insensitive-guard.js');
+
+const SCRIPT_PATH = path.join(__dirname, '../../pre-tool-use/case-insensitive-guard.js');
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fake filesystem builder. `dirs`: map of dir -> entries[]. `dirPaths`: set of
+// paths that are directories (everything else present is a file). caseInsensitive
+// controls whether pathExists folds case.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeFsx(dirs, dirPaths, { caseInsensitive = true } = {}) {
+  const fold = (p) => caseInsensitive ? p.toLowerCase() : p;
+  const dirKey = Object.fromEntries(Object.keys(dirs).map(d => [fold(d), d]));
+  const allPaths = new Set();
+  for (const [d, entries] of Object.entries(dirs)) {
+    allPaths.add(fold(d));
+    for (const e of entries) allPaths.add(fold(path.join(d, e)));
+  }
+  const dirSet = new Set([...dirPaths].map(fold));
+  return {
+    listDir: (d) => dirs[dirKey[fold(d)]] ?? null,
+    pathExists: (p) => allPaths.has(fold(p)),
+    isDirectory: (p) => dirSet.has(fold(p)),
+  };
+}
+
+// Case-INSENSITIVE /repo with dir 'content' and file 'notes.txt', plus /repo/src
+// (empty dir) and /other (dir 'stuff'). Used by most unit tests.
+function ciFsx() {
+  return makeFsx(
+    { '/repo': ['content', 'notes.txt', 'src'], '/repo/content': [], '/repo/src': [], '/other': ['stuff'], '/other/stuff': [] },
+    ['/repo', '/repo/content', '/repo/src', '/other', '/other/stuff'],
+    { caseInsensitive: true },
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Unit: parsing helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Unit: splitSegments()', () => {
+  it('records the connector preceding each segment', () => {
+    assert.deepStrictEqual(splitSegments('a && b; c || d | e'), [
+      { text: 'a', connector: null },
+      { text: 'b', connector: '&&' },
+      { text: 'c', connector: ';' },
+      { text: 'd', connector: '||' },
+      { text: 'e', connector: '|' },
+    ]);
+  });
+  it('ignores operators inside quotes', () => {
+    assert.deepStrictEqual(splitSegments('echo "a && b" && c'), [
+      { text: 'echo "a && b"', connector: null },
+      { text: 'c', connector: '&&' },
+    ]);
+  });
+  it('splits on newlines', () => {
+    assert.deepStrictEqual(splitSegments('a\nb').map(s => s.text), ['a', 'b']);
+  });
+});
+
+describe('Unit: tokenize()', () => {
+  it('keeps quoted strings as one token and marks them quoted', () => {
+    const t = tokenize('rm -rf "My Dir"');
+    assert.strictEqual(t.length, 3);
+    assert.strictEqual(t[2].text, 'My Dir');
+    assert.strictEqual(t[2].quoted, true);
+  });
+  it('handles escaped spaces', () => {
+    assert.strictEqual(tokenize('rm My\\ Dir')[1].text, 'My Dir');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Unit: collision analysis on the fake case-insensitive volume
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Unit: analyzeCommand() — catches (true positives)', () => {
+  const fsx = ciFsx();
+  const at = (cmd, cwd = '/repo') => analyzeCommand(cmd, cwd, fsx);
+
+  it('plain rm -rf onto a case-variant dir (critical)', () => {
+    const hit = at('rm -rf Content');
+    assert.strictEqual(hit?.level, 'critical');
+    assert.strictEqual(hit.actual, 'content');
+  });
+  it('the compound form that sank PR #8: cd dir && rm -rf X', () => {
+    assert.strictEqual(analyzeCommand('cd /repo && rm -rf Content', '/', fsx)?.typed, 'Content');
+  });
+  it('rm flag/operand orderings', () => {
+    assert.ok(at('rm Content -rf'));
+    assert.ok(at('rm -r -f Content'));
+    assert.ok(at('rm --recursive Content'));
+  });
+  it('trailing slash and subdir paths', () => {
+    assert.ok(at('rm -rf Content/'));
+    const fsx2 = makeFsx({ '/repo': ['src'], '/repo/src': ['content'], '/repo/src/content': [] }, ['/repo', '/repo/src', '/repo/src/content']);
+    assert.ok(analyzeCommand('rm -rf src/Content', '/repo', fsx2));
+  });
+  it('rm behind sudo and env assignments', () => {
+    assert.ok(at('sudo rm -rf Content'));
+    assert.ok(at('FOO=1 rm -rf Content'));
+  });
+  it('multi-arg rm (collision not first)', () => {
+    assert.strictEqual(at('rm -rf notes.txt Content')?.typed, 'Content');
+  });
+  it('quoted, ./-relative and absolute targets', () => {
+    assert.ok(at('rm -rf "Content"'));
+    assert.ok(at('rm -rf ./Content'));
+    assert.ok(analyzeCommand('rm -rf /repo/Content', '/', fsx));
+  });
+  it('rm after a pipe', () => assert.ok(at('echo done | rm -rf Content')));
+  it('rmdir onto a case-variant dir (finding #2)', () => {
+    const empty = makeFsx({ '/repo': ['content'], '/repo/content': [] }, ['/repo', '/repo/content']);
+    assert.strictEqual(analyzeCommand('rmdir Content', '/repo', empty)?.cmd, 'rmdir');
+  });
+  it('rm -d onto a case-variant dir', () => {
+    const empty = makeFsx({ '/repo': ['content'], '/repo/content': [] }, ['/repo', '/repo/content']);
+    assert.ok(analyzeCommand('rm -d Content', '/repo', empty));
+  });
+  it('non-recursive rm of a case-variant FILE (high)', () => {
+    assert.strictEqual(at('rm Notes.txt')?.level, 'high');
+  });
+  it('mv overwriting a case-variant FILE (high)', () => {
+    const hit = at('mv content/x.txt Notes.txt');
+    assert.strictEqual(hit?.level, 'high');
+  });
+  it('mkdir/touch collisions (strict)', () => {
+    assert.strictEqual(at('mkdir -p Content')?.level, 'strict');
+    assert.strictEqual(at('touch Notes.txt')?.level, 'strict');
+  });
+  it('pushd changes dir like cd (finding #3/#8)', () => {
+    const fsx2 = makeFsx({ '/repo': ['src'], '/repo/src': ['content'], '/repo/src/content': [] }, ['/repo', '/repo/src', '/repo/src/content']);
+    assert.ok(analyzeCommand('pushd src && rm -rf Content', '/repo', fsx2));
+  });
+  it('find <path> -delete (finding #4)', () => {
+    assert.strictEqual(at('find Content -delete')?.cmd, 'find -delete');
+    assert.ok(at('find Content -type f -delete'));
+    assert.ok(at('find Content -exec rm {} +'));
+  });
+  it('cd to a MISSING dir then ; rm runs in the original dir (finding #1)', () => {
+    // cd nope fails → with ; the rm executes in /repo, which has content.
+    assert.ok(analyzeCommand('cd nope ; rm -rf Content', '/repo', fsx));
+    assert.ok(analyzeCommand('cd nope || rm -rf Content', '/repo', fsx));
+  });
+});
+
+describe('Unit: analyzeCommand() — allows (true negatives)', () => {
+  const fsx = ciFsx();
+  const at = (cmd, cwd = '/repo') => analyzeCommand(cmd, cwd, fsx);
+
+  it('exact-case deletes (intentional)', () => {
+    assert.strictEqual(at('rm -rf content'), null);
+    assert.strictEqual(at('rm notes.txt'), null);
+  });
+  it('glob targets (shell glob matching is case-sensitive)', () => {
+    assert.strictEqual(at('rm -rf Cont*'), null);
+  });
+  it('unresolvable targets: $VAR, $( ), backticks', () => {
+    assert.strictEqual(at('rm -rf $DIR/Content'), null);
+    assert.strictEqual(at('rm -rf $(pwd)/Content'), null);
+    assert.strictEqual(at('rm -rf `pwd`/Content'), null);
+  });
+  it('relative targets when cwd is unknown', () => {
+    assert.strictEqual(analyzeCommand('rm -rf Content', undefined, fsx), null);
+    assert.strictEqual(analyzeCommand('cd $X && rm -rf Content', '/repo', fsx), null);
+  });
+  it('still checks absolute targets when cwd is unknown', () => {
+    assert.ok(analyzeCommand('rm -rf /repo/Content', undefined, fsx));
+  });
+  it('cd AWAY from the collision dir via && (no false positive)', () => {
+    assert.strictEqual(analyzeCommand('cd /other && rm -rf Content', '/repo', fsx), null);
+  });
+  it('mv INTO a case-variant directory (contents preserved)', () => {
+    assert.strictEqual(at('mv notes.txt Content'), null);
+  });
+  it('case-only self-rename is the canonical fix (finding #5/#7)', () => {
+    const one = makeFsx({ '/repo': ['notes.txt'] }, ['/repo']);
+    assert.strictEqual(analyzeCommand('mv notes.txt Notes.txt', '/repo', one), null);
+    assert.strictEqual(analyzeCommand('mv notes.txt NOTES.TXT', '/repo', one), null);
+  });
+  it('plain rm of a case-variant DIRECTORY is a no-op → allowed (finding #6)', () => {
+    assert.strictEqual(at('rm Content'), null);
+    assert.strictEqual(at('rm -f Content'), null);
+  });
+  it('subshell ( cd sub && rm ) is scoped correctly (finding #9)', () => {
+    // src has no 'content', so this is harmless and must NOT be blocked.
+    assert.strictEqual(analyzeCommand('( cd src && rm -rf Content )', '/repo', fsx), null);
+  });
+  it('find without a delete predicate', () => {
+    assert.strictEqual(at('find Content -type f'), null);
+  });
+  it('unrelated safe commands', () => {
+    for (const cmd of ['ls -la', 'git status', 'npm test', 'echo Content', 'cat notes.txt', 'grep -r Content .']) {
+      assert.strictEqual(at(cmd), null, cmd);
+    }
+  });
+});
+
+describe('Unit: analyzeCommand() on a case-SENSITIVE volume', () => {
+  it('never blocks — the miscased command fails harmlessly on its own', () => {
+    const fsx = makeFsx({ '/repo': ['content', 'notes.txt'], '/repo/content': [] }, ['/repo', '/repo/content'], { caseInsensitive: false });
+    assert.strictEqual(analyzeCommand('rm -rf Content', '/repo', fsx), null);
+    assert.strictEqual(analyzeCommand('mkdir -p Content', '/repo', fsx), null);
+    assert.strictEqual(analyzeCommand('rmdir Content', '/repo', fsx), null);
+  });
+});
+
+describe('Unit: checkCommand() level gating', () => {
+  const fsx = ciFsx();
+  it('critical level only blocks recursive rm / find -delete', () => {
+    assert.strictEqual(checkCommand('rm -rf Content', '/repo', 'critical', fsx).blocked, true);
+    assert.strictEqual(checkCommand('rm Notes.txt', '/repo', 'critical', fsx).blocked, false);
+    assert.strictEqual(checkCommand('mkdir Content', '/repo', 'critical', fsx).blocked, false);
+  });
+  it('high level blocks non-recursive file deletes and mv, not mkdir', () => {
+    assert.strictEqual(checkCommand('rm Notes.txt', '/repo', 'high', fsx).blocked, true);
+    assert.strictEqual(checkCommand('mkdir -p Content', '/repo', 'high', fsx).blocked, false);
+  });
+  it('strict level blocks mkdir/touch collisions too', () => {
+    assert.strictEqual(checkCommand('mkdir -p Content', '/repo', 'strict', fsx).blocked, true);
+  });
+});
+
+describe('Config: structure', () => {
+  it('LEVELS are ordered', () => {
+    assert.strictEqual(LEVELS.critical, 1);
+    assert.strictEqual(LEVELS.high, 2);
+    assert.strictEqual(LEVELS.strict, 3);
+  });
+  it('ASK has boolean values for each level', () => {
+    for (const level of ['critical', 'high', 'strict']) assert.strictEqual(typeof ASK[level], 'boolean');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Integration: real subprocess, real filesystem
+// ─────────────────────────────────────────────────────────────────────────────
+
+const TEST_HOME = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'cig-home-')));
+
+function runHook(hookData, envOverrides = {}) {
+  return new Promise((resolve, reject) => {
+    const env = { ...process.env, HOME: TEST_HOME, ...envOverrides };
+    for (const key of Object.keys(env)) {
+      if (key.startsWith('HOOK_ASK_') && !(key in envOverrides)) delete env[key];
+    }
+    const child = spawn('node', [SCRIPT_PATH], { env });
+    let stdout = '';
+    child.stdout.on('data', (d) => { stdout += d; });
+    child.on('close', (code) => {
+      try { resolve({ code, output: JSON.parse(stdout.trim() || '{}') }); }
+      catch { reject(new Error(`Failed to parse output: ${stdout}`)); }
+    });
+    child.stdin.write(typeof hookData === 'string' ? hookData : JSON.stringify(hookData));
+    child.stdin.end();
+  });
+}
+
+const bash = (command, cwd) => ({ tool_name: 'Bash', tool_input: { command }, cwd, session_id: 'test', permission_mode: 'default' });
+
+describe('Integration: defensive stdin', () => {
+  it('garbage stdin yields {} exit 0', async () => {
+    const { code, output } = await runHook('not json{{');
+    assert.strictEqual(code, 0);
+    assert.deepStrictEqual(output, {});
+  });
+  it('empty stdin yields {} exit 0', async () => {
+    const { code, output } = await runHook('');
+    assert.strictEqual(code, 0);
+    assert.deepStrictEqual(output, {});
+  });
+  it('null payload yields {} exit 0', async () => {
+    const { code, output } = await runHook('null');
+    assert.strictEqual(code, 0);
+    assert.deepStrictEqual(output, {});
+  });
+  it('non-Bash tools pass through', async () => {
+    const { output } = await runHook({ tool_name: 'Read', tool_input: { file_path: '/x' } });
+    assert.deepStrictEqual(output, {});
+  });
+  it('safe commands pass through', async () => {
+    assert.deepStrictEqual((await runHook(bash('ls -la', '/tmp'))).output, {});
+  });
+});
+
+// Does this machine's tmpdir fold case? (macOS APFS: yes; Linux CI ext4: no)
+const TMP_IS_CASE_INSENSITIVE = (() => {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'cig-probe-'));
+  try {
+    fs.writeFileSync(path.join(d, 'casetest'), '');
+    return fs.existsSync(path.join(d, 'CASETEST'));
+  } finally { fs.rmSync(d, { recursive: true, force: true }); }
+})();
+
+describe('Integration: real collisions', { skip: !TMP_IS_CASE_INSENSITIVE && 'tmpdir is case-sensitive' }, () => {
+  function withRepo(fn) {
+    const d = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'cig-repo-')));
+    fs.mkdirSync(path.join(d, 'content'));
+    fs.writeFileSync(path.join(d, 'notes.txt'), 'x');
+    return Promise.resolve(fn(d)).finally(() => fs.rmSync(d, { recursive: true, force: true }));
+  }
+  const deny = (o) => o.hookSpecificOutput?.permissionDecision;
+
+  it('denies rm -rf onto a case-variant, both names in the reason', () =>
+    withRepo(async (d) => {
+      const { output } = await runHook(bash('rm -rf Content', d));
+      assert.strictEqual(deny(output), 'deny');
+      assert.match(output.hookSpecificOutput?.permissionDecisionReason ?? '', /\[case-collision\].*'Content'.*'content'/);
+    }));
+  it('denies the compound cd && rm form (PR #8 bypass)', () =>
+    withRepo(async (d) => {
+      assert.strictEqual(deny((await runHook(bash(`cd ${d} && rm -rf Content`, '/'))).output), 'deny');
+    }));
+  it('denies cd <missing> ; rm (the runs-in-original-dir bypass)', () =>
+    withRepo(async (d) => {
+      assert.strictEqual(deny((await runHook(bash('cd nope ; rm -rf Content', d))).output), 'deny');
+    }));
+  it('allows mkdir -p onto a case-variant (PR #8 false positive)', () =>
+    withRepo(async (d) => {
+      assert.deepStrictEqual((await runHook(bash('mkdir -p Content', d))).output, {});
+    }));
+  it('allows a case-only file rename', () =>
+    withRepo(async (d) => {
+      assert.deepStrictEqual((await runHook(bash('mv notes.txt Notes.txt', d))).output, {});
+    }));
+  it('allows exact-case rm', () =>
+    withRepo(async (d) => {
+      assert.deepStrictEqual((await runHook(bash('rm -rf content', d))).output, {});
+    }));
+  it('returns "ask" for a critical collision when HOOK_ASK_CRITICAL=true', () =>
+    withRepo(async (d) => {
+      const { output } = await runHook(bash('rm -rf Content', d), { HOOK_ASK_CRITICAL: 'true' });
+      assert.strictEqual(deny(output), 'ask');
+    }));
+});

--- a/site/index.html
+++ b/site/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>claude-code-hooks — guardrails for the Claude Code agent loop</title>
-<meta name="description" content="Tested hooks that intercept the Claude Code agent loop — read stdin, exit 0 to pass or exit 2 to block. Eight copy-paste hooks plus a seven-plugin marketplace you install with /plugin install <name>@claude-code-hooks.">
+<meta name="description" content="Tested hooks that intercept the Claude Code agent loop — read stdin, exit 0 to pass or exit 2 to block. Nine copy-paste hooks plus a seven-plugin marketplace you install with /plugin install <name>@claude-code-hooks.">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;450;500;600&family=JetBrains+Mono:ital,wght@0,400;0,500;0,700;1,400&display=swap" rel="stylesheet">
@@ -339,7 +339,7 @@
       <p class="hero-deck">
         Small programs that watch what <b>Claude Code</b> is about to do — and step in.
         Block a destructive command. Refuse to read a secret. Stage and format an edit.
-        Ping you on Slack. Eight <b>exhaustively tested</b> copy-paste hooks, plus a seven-plugin marketplace you install with one command.
+        Ping you on Slack. Nine <b>exhaustively tested</b> copy-paste hooks, plus a seven-plugin marketplace you install with one command.
       </p>
       <div class="cta-row">
         <a class="btn btn-primary" href="#install">
@@ -352,8 +352,8 @@
         </a>
       </div>
       <div class="hero-stats">
-        <div class="s"><b>15</b><span>Hooks + plugins</span></div>
-        <div class="s"><b class="accent">1165</b><span>Tests pass</span></div>
+        <div class="s"><b>16</b><span>Hooks + plugins</span></div>
+        <div class="s"><b class="accent">1216</b><span>Tests pass</span></div>
         <div class="s"><b>~80<small style="font-size:.7rem">ms</small></b><span>Per call</span></div>
         <div class="s"><b>0 · 2</b><span>Exit codes</span></div>
       </div>
@@ -439,7 +439,7 @@
     <div class="sec-head">
       <div>
         <div class="kicker">The catalog</div>
-        <h2>The copy-paste eight.</h2>
+        <h2>The copy-paste nine.</h2>
         <p style="font-family:var(--mono);font-size:.76rem;color:var(--faint);margin-top:.7rem">Want one-command installs instead? <a href="#marketplace" style="color:var(--pass);border-bottom:1px solid var(--pass-dim)">Seven plugins ↓</a></p>
       </div>
       <div class="aside">node + python<br>MIT licensed</div>
@@ -589,6 +589,24 @@
       </div>
     </article>
 
+    <!-- 09 -->
+    <article class="entry obs">
+      <div>
+        <div class="entry-meta"><span class="tag evt">PreToolUse</span><span class="tag">Bash</span><span class="tag rt">Node · ~80ms</span></div>
+        <h3><span class="no">09</span>case-insensitive-guard</h3>
+        <p>On APFS, exFAT and NTFS, <em>Content</em> and <em>content</em> are the same path — an agent typing the wrong case deletes the real thing. Resolves every <em>rm</em>/<em>mv</em> target through <em>cd</em> chains and quotes, and blocks only provable case-collisions.</p>
+      </div>
+      <div class="term">
+        <div class="term-bar"><div class="term-dots"><i></i><i></i><i></i></div><div class="term-title">case-insensitive-guard</div></div>
+        <div class="term-body">
+          <span class="l"><span class="key">tool</span>    <span class="val">Bash</span></span>
+          <span class="l"><span class="key">command</span> <span class="val">cd app && rm -rf Content</span></span>
+          <span class="l verdict block"><span class="badge">⊘ blocked</span><span class="code">exit 2</span></span>
+          <span class="l verdict-note">"'content' exists — same path on this disk"</span>
+        </div>
+      </div>
+    </article>
+
     <p style="font-family:var(--mono);font-size:.8rem;color:var(--faint);margin-top:2rem;padding-top:1.5rem;border-top:1px solid var(--line)">
       + <span style="color:var(--dim)">event-logger</span> — a Python diagnostic that dumps every event's JSON so you can see an event's shape before you write a hook against it. The thing you reach for first.
     </p>
@@ -622,49 +640,49 @@
     <div class="mkt-grid">
       <!-- 07 -->
       <article class="pcard obs">
-        <h3><span class="no">09</span>context-hogs</h3>
+        <h3><span class="no">10</span>context-hogs</h3>
         <p>Per-file context-cost leaderboard — which files eat your tokens.</p>
         <span class="cmd">/context-hogs:leaderboard</span>
         <div class="events"><span class="tag evt">PostToolUse</span><span class="tag evt">SessionEnd</span></div>
       </article>
       <!-- 08 -->
       <article class="pcard obs">
-        <h3><span class="no">10</span>nerf-receipts</h3>
+        <h3><span class="no">11</span>nerf-receipts</h3>
         <p>Personal model-quality flight recorder — your own receipts when Claude feels nerfed.</p>
         <span class="cmd">/nerf-receipts:receipts</span>
         <div class="events"><span class="tag evt">SessionStart</span><span class="tag evt">PostToolUse</span><span class="tag evt">PostToolUseFailure</span><span class="tag evt">Stop</span><span class="tag evt">SubagentStop</span><span class="tag evt">SessionEnd</span></div>
       </article>
       <!-- 09 -->
       <article class="pcard obs">
-        <h3><span class="no">11</span>dead-rules-audit</h3>
+        <h3><span class="no">12</span>dead-rules-audit</h3>
         <p>CLAUDE.md compliance scorecard — which rules Claude actually ignores.</p>
         <span class="cmd">/dead-rules-audit:scorecard</span>
         <div class="events"><span class="tag evt">SessionStart</span><span class="tag evt">PostToolUse</span><span class="tag evt">SessionEnd</span></div>
       </article>
       <!-- 10 -->
       <article class="pcard obs">
-        <h3><span class="no">12</span>pr-provenance-stamp</h3>
+        <h3><span class="no">13</span>pr-provenance-stamp</h3>
         <p>Stamps a prompts / spend / tests / agent-authored receipt into PR bodies on <em style="font-style:normal;color:var(--text)">gh pr create</em>.</p>
         <span class="cmd">/pr-provenance-stamp:provenance</span>
         <div class="events"><span class="tag evt">PreToolUse</span><span class="tag evt">PostToolUse</span></div>
       </article>
       <!-- 11 -->
       <article class="pcard obs">
-        <h3><span class="no">13</span>standup-autopilot</h3>
+        <h3><span class="no">14</span>standup-autopilot</h3>
         <p>Writes your standup from what your agents actually did; re-injects yesterday's blockers.</p>
         <span class="cmd">/standup-autopilot:standup</span>
         <div class="events"><span class="tag evt">SessionStart</span><span class="tag evt">Stop</span><span class="tag evt">SessionEnd</span></div>
       </article>
       <!-- 12 -->
       <article class="pcard obs">
-        <h3><span class="no">14</span>dead-end-registry</h3>
+        <h3><span class="no">15</span>dead-end-registry</h3>
         <p>Remembers tried-and-reverted approaches; warns before you pay for a dead end twice.</p>
         <span class="cmd">/dead-end-registry:dead-ends</span>
         <div class="events"><span class="tag evt">UserPromptSubmit</span><span class="tag evt">PreToolUse</span><span class="tag evt">Stop</span><span class="tag evt">SubagentStop</span><span class="tag evt">PreCompact</span></div>
       </article>
       <!-- 13 -->
       <article class="pcard obs">
-        <h3><span class="no">15</span>bounty-board</h3>
+        <h3><span class="no">16</span>bounty-board</h3>
         <p>Prices TODO/FIXME debt as aging XP bounties; agents clear them as side quests.</p>
         <span class="cmd">/bounty-board:board</span>
         <div class="events"><span class="tag evt">SessionStart</span><span class="tag evt">PostToolUse</span><span class="tag evt">SessionEnd</span></div>
@@ -682,7 +700,7 @@
       <div>
         <div class="kicker">The classic path</div>
         <h2>Copy. Register. Restart.</h2>
-        <p style="font-family:var(--mono);font-size:.76rem;color:var(--faint);margin-top:.7rem">This is the copy-paste eight. The seven plugins install with <a href="#marketplace" style="color:var(--pass);border-bottom:1px solid var(--pass-dim)">/plugin ↑</a> instead.</p>
+        <p style="font-family:var(--mono);font-size:.76rem;color:var(--faint);margin-top:.7rem">This is the copy-paste nine. The seven plugins install with <a href="#marketplace" style="color:var(--pass);border-bottom:1px solid var(--pass-dim)">/plugin ↑</a> instead.</p>
       </div>
       <div class="aside">~60 seconds<br>no build step</div>
     </div>
@@ -781,19 +799,19 @@
       <div class="aside">contributions welcome<br>see CONTRIBUTING.md</div>
     </div>
     <div class="index">
-      <div class="ix"><span class="n">16</span><span class="nm">context-snapshot <span>— preserve before compaction</span></span><span class="evt">PreCompact</span></div>
-      <div class="ix"><span class="n">17</span><span class="nm">ntfy-notify <span>— free mobile push</span></span><span class="evt">Notification</span></div>
-      <div class="ix"><span class="n">18</span><span class="nm">discord-notify <span>— webhook alerts</span></span><span class="evt">Notification</span></div>
-      <div class="ix"><span class="n">19</span><span class="nm">tts-alerts <span>— voice notifications via say/espeak</span></span><span class="evt">Notification</span></div>
-      <div class="ix"><span class="n">20</span><span class="nm">rules-injector <span>— auto-attach CLAUDE.md</span></span><span class="evt">UserPromptSubmit</span></div>
-      <div class="ix"><span class="n">21</span><span class="nm">rate-limiter <span>— cap tool calls per minute</span></span><span class="evt">PreToolUse</span></div>
+      <div class="ix"><span class="n">17</span><span class="nm">context-snapshot <span>— preserve before compaction</span></span><span class="evt">PreCompact</span></div>
+      <div class="ix"><span class="n">18</span><span class="nm">ntfy-notify <span>— free mobile push</span></span><span class="evt">Notification</span></div>
+      <div class="ix"><span class="n">19</span><span class="nm">discord-notify <span>— webhook alerts</span></span><span class="evt">Notification</span></div>
+      <div class="ix"><span class="n">20</span><span class="nm">tts-alerts <span>— voice notifications via say/espeak</span></span><span class="evt">Notification</span></div>
+      <div class="ix"><span class="n">21</span><span class="nm">rules-injector <span>— auto-attach CLAUDE.md</span></span><span class="evt">UserPromptSubmit</span></div>
+      <div class="ix"><span class="n">22</span><span class="nm">rate-limiter <span>— cap tool calls per minute</span></span><span class="evt">PreToolUse</span></div>
     </div>
   </section>
 
   <!-- ═══════ CLOSING ═══════ -->
   <section class="close">
     <h2>Put a hook in the loop.</h2>
-    <p>Fifteen tested tools — eight copy-paste guardrails plus seven one-command plugins, MIT licensed, no framework to learn. Install one and restart Claude Code — you're protected in under a minute.</p>
+    <p>Sixteen tested tools — nine copy-paste guardrails plus seven one-command plugins, MIT licensed, no framework to learn. Install one and restart Claude Code — you're protected in under a minute.</p>
     <div class="cta-row">
       <a class="btn btn-primary" href="https://github.com/karanb192/claude-code-hooks">
         <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.5 2 2 6.6 2 12.2c0 4.5 2.9 8.3 6.8 9.7.5.1.7-.2.7-.5v-1.7c-2.8.6-3.4-1.4-3.4-1.4-.5-1.2-1.1-1.5-1.1-1.5-.9-.6.1-.6.1-.6 1 .1 1.5 1 1.5 1 .9 1.6 2.4 1.1 3 .9.1-.7.4-1.1.6-1.4-2.2-.3-4.6-1.1-4.6-5 0-1.1.4-2 1-2.7-.1-.3-.4-1.3.1-2.7 0 0 .8-.3 2.7 1a9.3 9.3 0 0 1 5 0c1.9-1.3 2.7-1 2.7-1 .5 1.4.2 2.4.1 2.7.6.7 1 1.6 1 2.7 0 3.9-2.4 4.7-4.6 5 .4.3.7.9.7 1.9v2.8c0 .3.2.6.7.5 3.9-1.4 6.8-5.2 6.8-9.7C22 6.6 17.5 2 12 2Z"/></svg>

--- a/site/index.html
+++ b/site/index.html
@@ -353,7 +353,7 @@
       </div>
       <div class="hero-stats">
         <div class="s"><b>16</b><span>Hooks + plugins</span></div>
-        <div class="s"><b class="accent">1216</b><span>Tests pass</span></div>
+        <div class="s"><b class="accent">1238</b><span>Tests pass</span></div>
         <div class="s"><b>~80<small style="font-size:.7rem">ms</small></b><span>Per call</span></div>
         <div class="s"><b>0 · 2</b><span>Exit codes</span></div>
       </div>


### PR DESCRIPTION
Closes #31.

On case-insensitive filesystems (APFS default, exFAT, NTFS), `Content` and `content` are the same path — so a recursive delete of `content` silently destroys `Content/` (the incident @yurukusa dug up: anthropics/claude-code#37875). This PreToolUse hook resolves the real target directory of destructive Bash commands and denies (or asks, via `HOOK_ASK_*`) the ones that would hit a case-variant of what was typed.

**Idea credit: @yurukusa** (PR #8) — reimplemented to house standards per the plan in #31.

## How it works
- No probe files: case-insensitivity is proven by the collision itself — the typed basename is absent from `readdir()` yet the path still exists.
- Shell-state model: candidate-cwd set + last exit status gating `&&`/`||`, quote-aware segment/token parsing, a real `pushd`/`popd` stack, subshell `( … )` snapshots, heredoc stripping, wrapper-prefix peeling (`nohup`, `exec`, `sudo`, …), and `cd` in background/pipeline positions not moving the parent shell.
- Covers `rm`/`rmdir`/`mv`/`find -delete`/`-exec rm` at `critical`/`high`, plus `mkdir`/`touch` at `strict`. Deliberate non-flags documented in the header (globs, `$VAR`, exact-case deletes, case-only self-renames, `mv -t`, plain `rm` on a dir).

## Hardening
Two adversarial review rounds (Opus attacker/verifier agents): round 1 found 9 confirmed issues, round 2 found 5 fail-open bypasses + 2 false positives — all fixed and locked by tests, with every bypass live-verified against real APFS.

## Tests
73 hook tests (deterministic fake-fs units + real-volume integration tests that self-skip on case-sensitive tmpdirs). Full suite: **1238 passing**.