### PR TITLE
site: no em dashes in title and meta description

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -3,8 +3,8 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>claude-code-hooks — guardrails for the Claude Code agent loop</title>
-<meta name="description" content="Tested hooks that intercept the Claude Code agent loop — read stdin, exit 0 to pass or exit 2 to block. Nine copy-paste hooks plus a seven-plugin marketplace you install with /plugin install <name>@claude-code-hooks.">
+<title>claude-code-hooks: guardrails for the Claude Code agent loop</title>
+<meta name="description" content="Tested hooks that intercept the Claude Code agent loop: read stdin, exit 0 to pass or exit 2 to block. Nine copy-paste hooks plus a seven-plugin marketplace you install with /plugin install <name>@claude-code-hooks.">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;450;500;600&family=JetBrains+Mono:ital,wght@0,400;0,500;0,700;1,400&display=swap" rel="stylesheet">


### PR DESCRIPTION
Two em dashes in the highest-visibility strings (browser tab title, search snippet) replaced with colons, per the house style. The rest of the page's dashes are left to the in-flight landing-page rewrite (add-landing-page-site) to avoid manufacturing conflicts; that rewrite should run the dash grep before it ships.