### PR TITLE
feat(bench): add hook latency harness with committed results

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ node --test hook-scripts/tests/pre-tool-use/block-dangerous-commands.test.js
 
 ## ⚡ Performance
 
-A synchronous hook adds its full runtime to every matching tool call, so these hooks aim to stay well under 100 ms end to end. Measured with a fresh Node process per call and a realistic event on stdin, `block-dangerous-commands` runs at a 34.8 ms median on an Apple M3 Pro (Node v26). The harness and committed numbers live in [`bench/`](bench/); reproduce with `node bench/run.mjs`.
+A synchronous hook adds its full runtime to every matching tool call. Measured with a fresh Node process per call and a realistic event on stdin, every guard hook here holds a 34-38 ms median on an Apple M3 Pro (Node v26). The two PostToolUse hooks that spawn real subprocesses cost more: auto-stage 68 ms with two git calls, format-code 114 ms with two ruff runs. The harness and committed numbers for all seven hooks live in [`bench/`](bench/); reproduce with `node bench/run.mjs`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -236,6 +236,12 @@ node --test hook-scripts/tests/pre-tool-use/block-dangerous-commands.test.js
 
 ---
 
+## ⚡ Performance
+
+A synchronous hook adds its full runtime to every matching tool call, so these hooks aim to stay well under 100 ms end to end. Measured with a fresh Node process per call and a realistic event on stdin, `block-dangerous-commands` runs at a 34.8 ms median on an Apple M3 Pro (Node v26). The harness and committed numbers live in [`bench/`](bench/); reproduce with `node bench/run.mjs`.
+
+---
+
 ## 📖 Configuration Reference
 
 See the [official Claude Code hooks documentation](https://docs.anthropic.com/en/docs/claude-code/hooks) for:

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,28 @@
+# Hook latency bench
+
+Measures what a user actually pays per tool call: the full lifecycle of one hook invocation. Each sample spawns a fresh Node process, writes a realistic benign event JSON to stdin (shaped like the hook's own test fixtures), and reads the verdict from stdout. Per hook: 1 discarded warm-up, then N timed samples (default 20).
+
+## Run
+
+```bash
+node bench/run.mjs            # print markdown table
+node bench/run.mjs --n=50     # more samples
+node bench/run.mjs --write    # also update bench/RESULTS.md
+```
+
+No dependencies. HOME is pointed at a throwaway temp dir during the run, so hook logs never touch your real `~/.claude`. `auto-stage` gets a temp git repo so it exercises its real `git rev-parse` + `git add` path.
+
+## Reading the results
+
+- Median is the headline number; min/max show spread.
+- Numbers are dominated by Node interpreter startup (~30 ms on an M3 Pro), not hook logic. They are an upper bound on per-call overhead on that machine, not a cross-machine latency ladder.
+- `auto-stage` is slower because it spawns two git subprocesses per call. That is its real cost, not harness overhead.
+
+## Scope
+
+Covers the PreToolUse/PostToolUse hooks in `hook-scripts/`. Excluded:
+
+- `notification/notify-permission.js`: a Notification hook, not on the tool-call path, and its real cost is a Slack webhook network call that a hermetic benchmark cannot represent honestly.
+- `utils/event-logger.py` and the hooks under `plugins/`: out of scope for this harness.
+
+Committed numbers: [RESULTS.md](RESULTS.md).

--- a/bench/README.md
+++ b/bench/README.md
@@ -17,12 +17,16 @@ No dependencies. HOME is pointed at a throwaway temp dir during the run, so hook
 - Median is the headline number; min/max show spread.
 - Numbers are dominated by Node interpreter startup (~30 ms on an M3 Pro), not hook logic. They are an upper bound on per-call overhead on that machine, not a cross-machine latency ladder.
 - `auto-stage` is slower because it spawns two git subprocesses per call. That is its real cost, not harness overhead.
+- `format-code` is the most expensive: each call runs `uv run ruff check --fix` plus `uv run ruff format` on the touched file, two more subprocess spawns on top of Node startup. The harness verifies ruff really reformatted the sample file and aborts if it did not, so a machine without the formatters can never report a meaningless fast number.
 
 ## Scope
 
-Covers the PreToolUse/PostToolUse hooks in `hook-scripts/`. Excluded:
+Covers all seven PreToolUse/PostToolUse hooks in `hook-scripts/`: block-dangerous-commands, case-insensitive-guard, git-safety, protect-secrets, protect-tests, auto-stage, format-code. The format-code payload writes a small unformatted Python file, so `uv` and `ruff` must be on PATH (CI installs them); without them the run aborts instead of reporting a no-op.
+
+Excluded:
 
 - `notification/notify-permission.js`: a Notification hook, not on the tool-call path, and its real cost is a Slack webhook network call that a hermetic benchmark cannot represent honestly.
+- `session/session-logger.js`: runs at session start and end, never per tool call.
 - `utils/event-logger.py` and the hooks under `plugins/`: out of scope for this harness.
 
 Committed numbers: [RESULTS.md](RESULTS.md).

--- a/bench/RESULTS.md
+++ b/bench/RESULTS.md
@@ -2,14 +2,18 @@
 
 - Machine: Apple M3 Pro (darwin arm64)
 - Node: v26.5.0
-- Date: 2026-08-17
+- Date: 2026-08-18
 - Samples: 1 warm-up (discarded) + N=20 per hook, fresh process per invocation
 
 | Hook | Median (ms) | Min | Max | Mean |
 |------|------------:|----:|----:|-----:|
-| block-dangerous-commands.js | 34.8 | 32.7 | 40.3 | 35.4 |
-| protect-secrets.js | 34.7 | 32.0 | 53.1 | 36.9 |
-| auto-stage.js | 59.6 | 57.3 | 65.0 | 60.1 |
+| block-dangerous-commands.js | 37.5 | 34.1 | 48.5 | 38.4 |
+| case-insensitive-guard.js | 35.5 | 33.7 | 38.0 | 35.7 |
+| git-safety.js | 34.7 | 33.3 | 36.3 | 34.6 |
+| protect-secrets.js | 35.0 | 33.6 | 74.4 | 38.7 |
+| protect-tests.js | 35.6 | 32.8 | 42.4 | 35.7 |
+| auto-stage.js | 68.1 | 63.8 | 76.0 | 68.1 |
+| format-code.js | 113.6 | 111.1 | 125.4 | 114.8 |
 
 Single-machine spot measurement. Numbers are dominated by Node interpreter
 startup, not hook logic; treat them as an upper bound on per-call overhead,

--- a/bench/RESULTS.md
+++ b/bench/RESULTS.md
@@ -1,0 +1,18 @@
+# Hook latency results
+
+- Machine: Apple M3 Pro (darwin arm64)
+- Node: v26.5.0
+- Date: 2026-08-17
+- Samples: 1 warm-up (discarded) + N=20 per hook, fresh process per invocation
+
+| Hook | Median (ms) | Min | Max | Mean |
+|------|------------:|----:|----:|-----:|
+| block-dangerous-commands.js | 34.8 | 32.7 | 40.3 | 35.4 |
+| protect-secrets.js | 34.7 | 32.0 | 53.1 | 36.9 |
+| auto-stage.js | 59.6 | 57.3 | 65.0 | 60.1 |
+
+Single-machine spot measurement. Numbers are dominated by Node interpreter
+startup, not hook logic; treat them as an upper bound on per-call overhead,
+not a cross-machine latency ladder.
+
+Reproduce: `node bench/run.mjs --n=20 --write`

--- a/bench/run.mjs
+++ b/bench/run.mjs
@@ -14,6 +14,10 @@ import { fileURLToPath } from 'node:url';
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const N = Number((process.argv.find(a => a.startsWith('--n=')) || '--n=20').slice(4));
 const WRITE = process.argv.includes('--write');
+if (!Number.isInteger(N) || N < 1) {
+  console.error('invalid --n: expected a positive integer, e.g. --n=20');
+  process.exit(1);
+}
 
 // Sandbox HOME so hook logs (~/.claude/hooks-logs) never touch the real home,
 // plus a throwaway git repo so auto-stage exercises its real staging path.
@@ -23,6 +27,9 @@ fs.mkdirSync(repoDir);
 execSync('git init -q && git config user.email bench@bench && git config user.name bench', { cwd: repoDir });
 const stagedFile = path.join(repoDir, 'file.js');
 fs.writeFileSync(stagedFile, 'console.log("bench");\n');
+// Deliberately unformatted so format-code's ruff run has real work every sample.
+const pyFile = path.join(repoDir, 'script.py');
+const PY_UNFORMATTED = 'x=1\ny  =  2\n';
 
 const base = { session_id: 'bench-session', cwd: repoDir, permission_mode: 'default' };
 
@@ -35,14 +42,42 @@ const HOOKS = [
       tool_input: { command: 'git status && ls -la src/' } },
   },
   {
+    script: 'hook-scripts/pre-tool-use/case-insensitive-guard.js',
+    payload: { ...base, hook_event_name: 'PreToolUse', tool_name: 'Bash',
+      tool_input: { command: 'mkdir -p dist && mv notes.txt dist/archive.txt && rm -rf dist/cache' } },
+  },
+  {
+    script: 'hook-scripts/pre-tool-use/git-safety.js',
+    payload: { ...base, hook_event_name: 'PreToolUse', tool_name: 'Bash',
+      tool_input: { command: 'git status --short && git log --oneline -3' } },
+  },
+  {
     script: 'hook-scripts/pre-tool-use/protect-secrets.js',
     payload: { ...base, hook_event_name: 'PreToolUse', tool_name: 'Read',
       tool_input: { file_path: path.join(repoDir, 'src', 'index.js') } },
   },
   {
+    script: 'hook-scripts/pre-tool-use/protect-tests.js',
+    payload: { ...base, hook_event_name: 'PreToolUse', tool_name: 'Write',
+      tool_input: { file_path: path.join(repoDir, 'src', 'app.js'), content: 'module.exports = () => 42;\n' } },
+  },
+  {
     script: 'hook-scripts/post-tool-use/auto-stage.js',
     payload: { ...base, hook_event_name: 'PostToolUse', tool_name: 'Write',
       tool_input: { file_path: stagedFile, content: 'console.log("bench");\n' } },
+  },
+  {
+    script: 'hook-scripts/post-tool-use/format-code.js',
+    payload: { ...base, hook_event_name: 'PostToolUse', tool_name: 'Write',
+      tool_input: { file_path: pyFile, content: PY_UNFORMATTED } },
+    prepare: () => fs.writeFileSync(pyFile, PY_UNFORMATTED),
+    // The hook swallows a missing formatter (exit 0, '{}'), which would bench a
+    // no-op. Prove ruff really reformatted the sample or refuse to report.
+    verify: () => {
+      if (fs.readFileSync(pyFile, 'utf8') === PY_UNFORMATTED) {
+        throw new Error('format-code: ruff did not reformat the sample; install uv and ruff (CI does)');
+      }
+    },
   },
 ];
 
@@ -56,7 +91,10 @@ function invoke(hook) {
   const ms = Number(process.hrtime.bigint() - t0) / 1e6;
   if (res.status !== 0) throw new Error(`${hook.script} exited ${res.status}: ${res.stderr}`);
   const verdict = JSON.parse(res.stdout);
-  const decision = verdict.hookSpecificOutput?.permissionDecision;
+  // PreToolUse verdicts use hookSpecificOutput.permissionDecision; PostToolUse
+  // blocks use a top-level decision field. Either one means the payload was
+  // not benign to the hook.
+  const decision = verdict.hookSpecificOutput?.permissionDecision ?? verdict.decision;
   if (decision) throw new Error(`${hook.script} returned "${decision}" for a benign payload`);
   return ms;
 }
@@ -73,13 +111,21 @@ function stats(samples) {
 }
 
 const rows = [];
-for (const hook of HOOKS) {
-  invoke(hook); // warm-up, discarded
-  const samples = [];
-  for (let i = 0; i < N; i++) samples.push(invoke(hook));
-  rows.push({ name: path.basename(hook.script), ...stats(samples) });
+try {
+  for (const hook of HOOKS) {
+    hook.prepare?.();
+    invoke(hook); // warm-up, discarded
+    hook.verify?.();
+    const samples = [];
+    for (let i = 0; i < N; i++) {
+      hook.prepare?.();
+      samples.push(invoke(hook));
+    }
+    rows.push({ name: path.basename(hook.script), ...stats(samples) });
+  }
+} finally {
+  fs.rmSync(sandbox, { recursive: true, force: true });
 }
-fs.rmSync(sandbox, { recursive: true, force: true });
 
 const fmt = v => v.toFixed(1);
 const table = [

--- a/bench/run.mjs
+++ b/bench/run.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+// Hook latency benchmark. Times each PreToolUse/PostToolUse hook in
+// hook-scripts/ end-to-end: fresh Node process per invocation, realistic
+// event JSON on stdin, verdict read from stdout. See bench/README.md.
+//
+// Usage: node bench/run.mjs [--n=20] [--write]
+
+import { spawnSync, execSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const N = Number((process.argv.find(a => a.startsWith('--n=')) || '--n=20').slice(4));
+const WRITE = process.argv.includes('--write');
+
+// Sandbox HOME so hook logs (~/.claude/hooks-logs) never touch the real home,
+// plus a throwaway git repo so auto-stage exercises its real staging path.
+const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'cch-bench-'));
+const repoDir = path.join(sandbox, 'repo');
+fs.mkdirSync(repoDir);
+execSync('git init -q && git config user.email bench@bench && git config user.name bench', { cwd: repoDir });
+const stagedFile = path.join(repoDir, 'file.js');
+fs.writeFileSync(stagedFile, 'console.log("bench");\n');
+
+const base = { session_id: 'bench-session', cwd: repoDir, permission_mode: 'default' };
+
+// One benign payload per hook, shaped like the hook's own test fixtures.
+// Each must take the clean allow path (exit 0, no deny/ask in the verdict).
+const HOOKS = [
+  {
+    script: 'hook-scripts/pre-tool-use/block-dangerous-commands.js',
+    payload: { ...base, hook_event_name: 'PreToolUse', tool_name: 'Bash',
+      tool_input: { command: 'git status && ls -la src/' } },
+  },
+  {
+    script: 'hook-scripts/pre-tool-use/protect-secrets.js',
+    payload: { ...base, hook_event_name: 'PreToolUse', tool_name: 'Read',
+      tool_input: { file_path: path.join(repoDir, 'src', 'index.js') } },
+  },
+  {
+    script: 'hook-scripts/post-tool-use/auto-stage.js',
+    payload: { ...base, hook_event_name: 'PostToolUse', tool_name: 'Write',
+      tool_input: { file_path: stagedFile, content: 'console.log("bench");\n' } },
+  },
+];
+
+function invoke(hook) {
+  const t0 = process.hrtime.bigint();
+  const res = spawnSync(process.execPath, [path.join(ROOT, hook.script)], {
+    input: JSON.stringify(hook.payload),
+    encoding: 'utf8',
+    env: { ...process.env, HOME: sandbox },
+  });
+  const ms = Number(process.hrtime.bigint() - t0) / 1e6;
+  if (res.status !== 0) throw new Error(`${hook.script} exited ${res.status}: ${res.stderr}`);
+  const verdict = JSON.parse(res.stdout);
+  const decision = verdict.hookSpecificOutput?.permissionDecision;
+  if (decision) throw new Error(`${hook.script} returned "${decision}" for a benign payload`);
+  return ms;
+}
+
+function stats(samples) {
+  const s = [...samples].sort((a, b) => a - b);
+  const mid = Math.floor(s.length / 2);
+  return {
+    median: s.length % 2 ? s[mid] : (s[mid - 1] + s[mid]) / 2,
+    min: s[0],
+    max: s[s.length - 1],
+    mean: s.reduce((a, b) => a + b, 0) / s.length,
+  };
+}
+
+const rows = [];
+for (const hook of HOOKS) {
+  invoke(hook); // warm-up, discarded
+  const samples = [];
+  for (let i = 0; i < N; i++) samples.push(invoke(hook));
+  rows.push({ name: path.basename(hook.script), ...stats(samples) });
+}
+fs.rmSync(sandbox, { recursive: true, force: true });
+
+const fmt = v => v.toFixed(1);
+const table = [
+  '| Hook | Median (ms) | Min | Max | Mean |',
+  '|------|------------:|----:|----:|-----:|',
+  ...rows.map(r => `| ${r.name} | ${fmt(r.median)} | ${fmt(r.min)} | ${fmt(r.max)} | ${fmt(r.mean)} |`),
+].join('\n');
+
+console.log(table);
+
+if (WRITE) {
+  const doc = `# Hook latency results
+
+- Machine: ${os.cpus()[0].model} (${os.platform()} ${os.arch()})
+- Node: ${process.version}
+- Date: ${new Date().toISOString().slice(0, 10)}
+- Samples: 1 warm-up (discarded) + N=${N} per hook, fresh process per invocation
+
+${table}
+
+Single-machine spot measurement. Numbers are dominated by Node interpreter
+startup, not hook logic; treat them as an upper bound on per-call overhead,
+not a cross-machine latency ladder.
+
+Reproduce: \`node bench/run.mjs --n=${N} --write\`
+`;
+  fs.writeFileSync(path.join(ROOT, 'bench', 'RESULTS.md'), doc);
+  console.log('\nWrote bench/RESULTS.md');
+}


### PR DESCRIPTION
## Why

The README talks about hook latency but the repo had no way to measure it. Perf claims should be reproducible, not asserted. This adds a small harness plus committed results so any claim about hook overhead points at a number you can regenerate with one command.

## Method

`bench/run.mjs`, zero npm dependencies like the rest of the repo:

- Times all seven PreToolUse/PostToolUse hooks in `hook-scripts/` end to end: fresh Node process per invocation, realistic benign event JSON on stdin (shaped like each hook's own test fixtures), verdict read from stdout and checked for a clean allow (both the PreToolUse `permissionDecision` shape and the PostToolUse `decision` shape).
- 1 discarded warm-up, then N samples per hook (default 20, `--n=` to change, validated). Reports median/min/max/mean; `--write` regenerates `bench/RESULTS.md`.
- HOME is pointed at a throwaway temp dir so hook logs never touch the real `~/.claude` (cleaned up even on a crashed run). `auto-stage` gets a temp git repo so it exercises its real `git rev-parse` + `git add` path; `format-code` gets a deliberately unformatted Python file rewritten before every sample, and the harness proves ruff actually reformatted it, aborting rather than timing a no-op on a machine without the formatters.
- Excluded: `notify-permission` (Notification hook off the tool-call path; its real cost is a Slack webhook network call) and `session-logger` (session lifecycle, never per tool call). Rationale in `bench/README.md`.

## Results (Apple M3 Pro, Node v26.5.0, 2026-08-18, N=20)

| Hook | Median (ms) | Min | Max | Mean |
|------|------------:|----:|----:|-----:|
| block-dangerous-commands.js | 37.5 | 34.1 | 48.5 | 38.4 |
| case-insensitive-guard.js | 35.5 | 33.7 | 38.0 | 35.7 |
| git-safety.js | 34.7 | 33.3 | 36.3 | 34.6 |
| protect-secrets.js | 35.0 | 33.6 | 74.4 | 38.7 |
| protect-tests.js | 35.6 | 32.8 | 42.4 | 35.7 |
| auto-stage.js | 68.1 | 63.8 | 76.0 | 68.1 |
| format-code.js | 113.6 | 111.1 | 125.4 | 114.8 |

Single-machine spot measurement, dominated by Node interpreter startup. The subprocess spawners carry their real cost: auto-stage runs two git calls per invocation, format-code two `uv run ruff` calls.

The main README gains one short Performance subsection linking here; the diff is confined to a single spot.

## Tests

```
tests 1238
suites 233
pass 1238
fail 0
cancelled 0
skipped 0
todo 0
```