### PR TITLE
chore: clean the dash stragglers the glob-based sweep missed

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "context-hogs",
       "source": "./plugins/context-hogs",
-      "description": "Per-file context-cost leaderboard — attributes every tool result's tokens to the files it loaded, so you know which files cost you the most.",
+      "description": "Per-file context-cost leaderboard: attributes every tool result's tokens to the files it loaded, so you know which files cost you the most.",
       "category": "cost",
       "tags": [
         "cost",
@@ -23,7 +23,7 @@
     {
       "name": "nerf-receipts",
       "source": "./plugins/nerf-receipts",
-      "description": "A personal flight recorder for Claude Code quality — records your own per-session failure rate, edit churn, and tokens/task by model version, and flags real shifts when a model changes.",
+      "description": "A personal flight recorder for Claude Code quality: records your own per-session failure rate, edit churn, and tokens/task by model version, and flags real shifts when a model changes.",
       "category": "observability",
       "tags": [
         "quality",
@@ -36,7 +36,7 @@
     {
       "name": "dead-rules-audit",
       "source": "./plugins/dead-rules-audit",
-      "description": "CLAUDE.md compliance scorecard — tallies which rules Claude actually follows vs ignores as you edit, and flags chronically-ignored rules to promote into a deterministic hook.",
+      "description": "CLAUDE.md compliance scorecard: tallies which rules Claude actually follows vs ignores as you edit, and flags chronically-ignored rules to promote into a deterministic hook.",
       "category": "observability",
       "tags": [
         "compliance",
@@ -51,7 +51,7 @@
     {
       "name": "pr-provenance-stamp",
       "source": "./plugins/pr-provenance-stamp",
-      "description": "Stamps a provenance receipt — prompts, estimated spend, tests run with exit codes, and a truthful agent-authored line split — into your PR body on `gh pr create`.",
+      "description": "Stamps a provenance receipt (prompts, estimated spend, tests run with exit codes, and a truthful agent-authored line split) into your PR body on `gh pr create`.",
       "category": "git",
       "tags": [
         "pr",
@@ -65,7 +65,7 @@
     {
       "name": "standup-autopilot",
       "source": "./plugins/standup-autopilot",
-      "description": "Writes your daily standup from what your agents actually did across repos — captures tasks, tests, PRs, and blockers from session transcripts and re-injects yesterday's open blockers next session.",
+      "description": "Writes your daily standup from what your agents actually did across repos: captures tasks, tests, PRs, and blockers from session transcripts and re-injects yesterday's open blockers next session.",
       "category": "productivity",
       "tags": [
         "standup",
@@ -79,7 +79,7 @@
     {
       "name": "dead-end-registry",
       "source": "./plugins/dead-end-registry",
-      "description": "Remembers approaches you tried and reverted (with reason and estimated token cost) and warns before you retry them — via a prompt-submit card and an ask-before-edit guard.",
+      "description": "Remembers approaches you tried and reverted (with reason and estimated token cost) and warns before you retry them, via a prompt-submit card and an ask-before-edit guard.",
       "category": "memory",
       "tags": [
         "memory",

--- a/plugins/bounty-board/.claude-plugin/plugin.json
+++ b/plugins/bounty-board/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "bounty-board",
-  "description": "Turns your repo's tech debt into an aging bounty economy. A SessionStart hook scans tracked files and prices each TODO/FIXME/HACK/skip as a wanted-poster bounty whose XP grows with its git-blame age, injects the top 3 as opportunistic side quests, and — via a PostToolUse hook — verifies and pays out bounties that genuinely disappear. SessionEnd renders a payout card, and /bounty-board:board shows the current board on demand.",
-  "version": "1.0.2",
+  "description": "Turns your repo's tech debt into an aging bounty economy. A SessionStart hook scans tracked files and prices each TODO/FIXME/HACK/skip as a wanted-poster bounty whose XP grows with its git-blame age, injects the top 3 as opportunistic side quests, and, via a PostToolUse hook, verifies and pays out bounties that genuinely disappear. SessionEnd renders a payout card, and /bounty-board:board shows the current board on demand.",
+  "version": "1.0.3",
   "author": {
     "name": "Karan Bansal",
     "url": "https://github.com/karanb192"

--- a/plugins/context-hogs/.claude-plugin/plugin.json
+++ b/plugins/context-hogs/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "context-hogs",
-  "description": "A per-file context-cost leaderboard for Claude Code. A PostToolUse hook (async, zero added latency) attributes every tool result's tokens to the file(s) it pulled into context; at SessionEnd — or on demand via /context-hogs:leaderboard — it renders your repo's most token-expensive files with estimated cost, so you know which files to trim.",
-  "version": "1.0.3",
+  "description": "A per-file context-cost leaderboard for Claude Code. A PostToolUse hook (async, zero added latency) attributes every tool result's tokens to the file(s) it pulled into context; at SessionEnd (or on demand via /context-hogs:leaderboard) it renders your repo's most token-expensive files with estimated cost, so you know which files to trim.",
+  "version": "1.0.4",
   "author": {
     "name": "Karan Bansal",
     "url": "https://github.com/karanb192"

--- a/plugins/dead-end-registry/.claude-plugin/plugin.json
+++ b/plugins/dead-end-registry/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dead-end-registry",
-  "description": "Approach-level negative-knowledge memory for Claude Code. Mines your transcripts (Stop/PreCompact, both async and zero added latency) for approaches you TRIED and then REVERTED — with the reason, date, and estimated token cost of the detour — into a per-repo registry. On UserPromptSubmit it injects a 'you already tried this' warning card when a new prompt matches a recorded dead end; on PreToolUse (Edit|Write) it asks before an edit reintroduces a previously-reverted hunk. Review the registry any time with /dead-end-registry:dead-ends.",
-  "version": "1.0.1",
+  "description": "Approach-level negative-knowledge memory for Claude Code. Mines your transcripts (Stop/PreCompact, both async and zero added latency) for approaches you TRIED and then REVERTED (with the reason, date, and estimated token cost of the detour) into a per-repo registry. On UserPromptSubmit it injects a 'you already tried this' warning card when a new prompt matches a recorded dead end; on PreToolUse (Edit|Write) it asks before an edit reintroduces a previously-reverted hunk. Review the registry any time with /dead-end-registry:dead-ends.",
+  "version": "1.0.2",
   "author": {
     "name": "Karan Bansal",
     "url": "https://github.com/karanb192"

--- a/plugins/dead-rules-audit/.claude-plugin/plugin.json
+++ b/plugins/dead-rules-audit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dead-rules-audit",
-  "description": "A CLAUDE.md compliance flight-recorder for Claude Code. At SessionStart it parses CLAUDE.md into numbered atomic rules; on every Edit/MultiEdit/Write a PostToolUse hook (async, zero added latency) passively tallies how often each rule was relevant and whether it was followed or violated; at SessionEnd — or on demand via /dead-rules-audit:scorecard — it renders a worst-first compliance scorecard with a promote-to-hook hint for chronically-ignored rules. Zero deps, zero network, fully deterministic.",
-  "version": "1.0.2",
+  "description": "A CLAUDE.md compliance flight-recorder for Claude Code. At SessionStart it parses CLAUDE.md into numbered atomic rules; on every Edit/MultiEdit/Write a PostToolUse hook (async, zero added latency) passively tallies how often each rule was relevant and whether it was followed or violated; at SessionEnd (or on demand via /dead-rules-audit:scorecard) it renders a worst-first compliance scorecard with a promote-to-hook hint for chronically-ignored rules. Zero deps, zero network, fully deterministic.",
+  "version": "1.0.3",
   "author": {
     "name": "Karan Bansal",
     "url": "https://github.com/karanb192"

--- a/plugins/nerf-receipts/.claude-plugin/plugin.json
+++ b/plugins/nerf-receipts/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nerf-receipts",
-  "description": "A personal flight recorder for Claude Code quality. Background hooks (async, zero added latency) record your own per-session signals keyed by model id and Claude Code version — tool-failure rate, same-file edit churn, turn-end counts, and tokens-per-completed-task. At your next SessionStart — or on demand via /nerf-receipts:receipts — it renders a trend card with sparklines and flags meaningful shifts that coincide with a model change, so the next time someone says \"they nerfed it\" you have data instead of vibes.",
-  "version": "1.0.2",
+  "description": "A personal flight recorder for Claude Code quality. Background hooks (async, zero added latency) record your own per-session signals keyed by model id and Claude Code version: tool-failure rate, same-file edit churn, turn-end counts, and tokens-per-completed-task. At your next SessionStart (or on demand via /nerf-receipts:receipts) it renders a trend card with sparklines and flags meaningful shifts that coincide with a model change, so the next time someone says \"they nerfed it\" you have data instead of vibes.",
+  "version": "1.0.3",
   "author": {
     "name": "Karan Bansal",
     "url": "https://github.com/karanb192"

--- a/plugins/pr-provenance-stamp/.claude-plugin/plugin.json
+++ b/plugins/pr-provenance-stamp/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pr-provenance-stamp",
-  "description": "Embeds a reviewer-facing provenance receipt into your PR body when Claude runs `gh pr create` (or `glab mr create`). A PostToolUse hook (async, zero added latency) records a per-session ledger — tool calls, agent-authored lines, and every test/typecheck command with its real exit code; a PreToolUse (Bash) hook then rewrites the --body on `gh pr create` with the real prompt count, estimated spend, test tally, and a truthful agent-vs-human authored-line split. Preview it anytime via /pr-provenance-stamp:provenance.",
-  "version": "1.0.1",
+  "description": "Embeds a reviewer-facing provenance receipt into your PR body when Claude runs `gh pr create` (or `glab mr create`). A PostToolUse hook (async, zero added latency) records a per-session ledger: tool calls, agent-authored lines, and every test/typecheck command with its real exit code; a PreToolUse (Bash) hook then rewrites the --body on `gh pr create` with the real prompt count, estimated spend, test tally, and a truthful agent-vs-human authored-line split. Preview it anytime via /pr-provenance-stamp:provenance.",
+  "version": "1.0.2",
   "author": {
     "name": "Karan Bansal",
     "url": "https://github.com/karanb192"

--- a/plugins/standup-autopilot/.claude-plugin/plugin.json
+++ b/plugins/standup-autopilot/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "standup-autopilot",
-  "description": "Turns what your agents ACTUALLY did into a standup — captured from session transcripts (not commits/tickets, which miss uncommitted work, real test exit codes, and unresolved errors) and rolled up cross-repo. Stop/SessionEnd snapshot each session's outcome (task, branch + diffstat, tests + exit codes, PRs, blockers) to a local per-day ledger; SessionStart re-injects yesterday's unresolved blockers via additionalContext and prints a standup-ready card. Render today's card any time via /standup-autopilot:standup.",
-  "version": "1.0.1",
+  "description": "Turns what your agents ACTUALLY did into a standup: captured from session transcripts (not commits/tickets, which miss uncommitted work, real test exit codes, and unresolved errors) and rolled up cross-repo. Stop/SessionEnd snapshot each session's outcome (task, branch + diffstat, tests + exit codes, PRs, blockers) to a local per-day ledger; SessionStart re-injects yesterday's unresolved blockers via additionalContext and prints a standup-ready card. Render today's card any time via /standup-autopilot:standup.",
+  "version": "1.0.2",
   "author": {
     "name": "Karan Bansal",
     "url": "https://github.com/karanb192"


### PR DESCRIPTION
## What

Finishes what #42 started. That cleanup walked files with Python's `glob('**/*.json')`, which does not descend into dot-directories, so 13 em dashes survived in `.claude-plugin/marketplace.json` (the six original plugin descriptions) and the seven original plugins' `.claude-plugin/plugin.json` descriptions. #42's verification pass used the same walker, which is why its "zero remaining" claim was wrong.

Replacements reuse #42's vocabulary so these descriptions now match their already-cleaned copies in the READMEs (parentheses for the paired interpolations, colons for appositives). Verification here uses `os.walk` with dot-directories included: zero em or en dashes remain outside `site/` (still excluded; the typeset redesign replaces it).

The seven touched plugins get patch bumps per the CONTRIBUTING versioning rule: bounty-board 1.0.3, context-hogs 1.0.4, dead-end-registry 1.0.2, dead-rules-audit 1.0.3, nerf-receipts 1.0.3, pr-provenance-stamp 1.0.2, standup-autopilot 1.0.2.

## Tests

`npm test`: 1544 pass, 0 fail. `claude plugin validate .`: passed.