### PR TITLE
site: catch the live page up with the 20-plugin reality

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>claude-code-hooks: guardrails for the Claude Code agent loop</title>
-<meta name="description" content="Tested hooks that intercept the Claude Code agent loop: read stdin, exit 0 to pass or exit 2 to block. Nineteen installable plugins: /plugin marketplace add karanb192/claude-code-hooks, then /plugin install <name>@claude-code-hooks.">
+<meta name="description" content="Tested hooks that intercept the Claude Code agent loop: read stdin, exit 0 to pass or exit 2 to block. Twenty installable plugins: /plugin marketplace add karanb192/claude-code-hooks, then /plugin install <name>@claude-code-hooks.">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;450;500;600&family=JetBrains+Mono:ital,wght@0,400;0,500;0,700;1,400&display=swap" rel="stylesheet">
@@ -337,9 +337,9 @@
         <span class="a">stdin</span><span class="arw">→</span>hook<span class="arw">→</span><span class="p">exit 0 · pass</span>&nbsp;&nbsp;/&nbsp;&nbsp;<span class="b">exit 2 · block</span>
       </div>
       <p class="hero-deck">
-        Small programs that watch what <b>Claude Code</b> is about to do — and step in.
+        Small programs that watch what <b>Claude Code</b> is about to do, and step in.
         Block a destructive command. Refuse to read a secret. Stage and format an edit.
-        Ping you on Slack. Nineteen <b>exhaustively tested</b> plugins, each one command to install.
+        Ping you on Slack. Twenty <b>exhaustively tested</b> plugins, each one command to install.
       </p>
       <div class="cta-row">
         <a class="btn btn-primary" href="#marketplace">
@@ -352,9 +352,9 @@
         </a>
       </div>
       <div class="hero-stats">
-        <div class="s"><b>19</b><span>Plugins</span></div>
-        <div class="s"><b class="accent">1544</b><span>Tests pass</span></div>
-        <div class="s"><b>~80<small style="font-size:.7rem">ms</small></b><span>Per call</span></div>
+        <div class="s"><b>20</b><span>Plugins</span></div>
+        <div class="s"><b class="accent">1570</b><span>Tests pass</span></div>
+        <div class="s"><b>~35<small style="font-size:.7rem">ms</small></b><span>Per call</span></div>
         <div class="s"><b>0 · 2</b><span>Exit codes</span></div>
       </div>
     </div>
@@ -363,7 +363,7 @@
       <div class="term">
         <div class="term-bar">
           <div class="term-dots"><i></i><i></i><i></i></div>
-          <div class="term-title">~/repo — claude</div>
+          <div class="term-title">~/repo - claude</div>
         </div>
         <div class="term-body animate">
           <span class="l comment"># Claude proposes an action…</span>
@@ -390,17 +390,17 @@
     </div>
     <div class="proto-grid">
       <div class="proto-card obs">
-        <div class="ic">01 — in</div>
+        <div class="ic">01 · in</div>
         <h3>Claude sends <code class="b">stdin</code></h3>
-        <p>On every lifecycle event, Claude Code pipes a JSON payload — the tool, its input, the session — to your hook's standard input.</p>
+        <p>On every lifecycle event, Claude Code pipes a JSON payload (the tool, its input, the session) to your hook's standard input.</p>
       </div>
       <div class="proto-card obs">
-        <div class="ic">02 — decide</div>
+        <div class="ic">02 · decide</div>
         <h3>Your hook runs</h3>
         <p>A few hundred lines in Node, Python, or shell. Inspect the payload, check it against your rules, and choose a verdict.</p>
       </div>
       <div class="proto-card obs">
-        <div class="ic">03 — out</div>
+        <div class="ic">03 · out</div>
         <h3>Return <code>exit 0</code> or <code class="b">exit 2</code></h3>
         <p><strong style="color:var(--pass)">0</strong> lets the tool run. <strong style="color:var(--block)">2</strong> blocks it and hands your message back to Claude as guidance.</p>
       </div>
@@ -421,7 +421,7 @@
         <div class="stop on"><div class="tick"></div><div class="nm">SessionStart</div><div class="nt">prepare context</div></div>
         <div class="stop on"><div class="tick"></div><div class="nm">UserPrompt</div><div class="nt">inspect / inject</div></div>
         <div class="stop on"><div class="tick"></div><div class="nm">PreToolUse</div><div class="nt">block or pass</div></div>
-        <div class="stop off"><div class="tick"></div><div class="nm">— tool —</div><div class="nt">execution</div></div>
+        <div class="stop off"><div class="tick"></div><div class="nm">· tool ·</div><div class="nt">execution</div></div>
         <div class="stop on"><div class="tick"></div><div class="nm">PostToolUse</div><div class="nt">react / log</div></div>
         <div class="stop on"><div class="tick"></div><div class="nm">Notification</div><div class="nt">alert you</div></div>
         <div class="stop on"><div class="tick"></div><div class="nm">Stop</div><div class="nt">finalize</div></div>
@@ -429,7 +429,7 @@
       </div>
     </div>
     <div class="rail-key">
-      <span><b>●</b> covered by this repo — SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, Notification, Stop, SessionEnd</span>
+      <span><b>●</b> covered by this repo: SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, Notification, Stop, SessionEnd</span>
       <span>○ the middle stop is tool execution; SubagentStop, PreCompact, ConfigChange, and InstructionsLoaded are covered too</span>
     </div>
   </section>
@@ -448,7 +448,7 @@
     <!-- 01 -->
     <article class="entry obs">
       <div>
-        <div class="entry-meta"><span class="tag evt">PreToolUse</span><span class="tag">Bash</span><span class="tag rt">Node · ~80ms</span></div>
+        <div class="entry-meta"><span class="tag evt">PreToolUse</span><span class="tag">Bash</span><span class="tag rt">Node · ~35ms</span></div>
         <h3><span class="no">01</span>block-dangerous-commands</h3>
         <p>Refuses <em>rm -rf ~</em>, fork bombs, <em>curl | sh</em>, <em>dd</em> to a raw disk, and the long tail of catastrophes that look harmless in a one-liner. Three tunable safety levels decide where the line sits.</p>
       </div>
@@ -466,9 +466,9 @@
     <!-- 02 -->
     <article class="entry rev obs">
       <div>
-        <div class="entry-meta"><span class="tag evt">PreToolUse</span><span class="tag">Read·Edit·Write·Bash</span><span class="tag rt">Node · ~80ms</span></div>
+        <div class="entry-meta"><span class="tag evt">PreToolUse</span><span class="tag">Read·Edit·Write·Bash</span><span class="tag rt">Node · ~35ms</span></div>
         <h3><span class="no">02</span>protect-secrets</h3>
-        <p>Stops Claude from reading, editing, or quietly exfiltrating <em>.env</em> files, SSH keys, AWS credentials, kubeconfig — anything load-bearing. Catches the obvious paths and the clever ones: a <em>cat</em> piped to <em>curl</em> is still exfiltration.</p>
+        <p>Stops Claude from reading, editing, or quietly exfiltrating <em>.env</em> files, SSH keys, AWS credentials, kubeconfig: anything load-bearing. Catches the obvious paths and the clever ones: a <em>cat</em> piped to <em>curl</em> is still exfiltration.</p>
       </div>
       <div class="term">
         <div class="term-bar"><div class="term-dots"><i></i><i></i><i></i></div><div class="term-title">protect-secrets</div></div>
@@ -484,7 +484,7 @@
     <!-- 03 -->
     <article class="entry obs">
       <div>
-        <div class="entry-meta"><span class="tag evt">PreToolUse</span><span class="tag">Bash</span><span class="tag rt">Node · ~80ms</span></div>
+        <div class="entry-meta"><span class="tag evt">PreToolUse</span><span class="tag">Bash</span><span class="tag rt">Node · ~35ms</span></div>
         <h3><span class="no">03</span>git-safety</h3>
         <p>Branch-aware guardrails: blocks commit, merge, rebase, reset and push while you're on <em>main</em>, plus destructive <em>gh</em> CLI calls like <em>gh repo delete</em>. Complements block-dangerous-commands rather than overlapping it.</p>
       </div>
@@ -502,9 +502,9 @@
     <!-- 04 -->
     <article class="entry rev obs">
       <div>
-        <div class="entry-meta"><span class="tag evt">PostToolUse</span><span class="tag">Edit·Write</span><span class="tag rt">Node · ~60ms</span></div>
+        <div class="entry-meta"><span class="tag evt">PostToolUse</span><span class="tag">Edit·Write</span><span class="tag rt">Node · ~65ms</span></div>
         <h3><span class="no">04</span>auto-stage</h3>
-        <p>After Claude edits or creates a file, runs <em>git add</em> on it — so <em>git diff --cached</em> becomes the canonical "what did the agent just do" view. One less accounting step in your loop.</p>
+        <p>After Claude edits or creates a file, runs <em>git add</em> on it, so <em>git diff --cached</em> becomes the canonical "what did the agent just do" view. One less accounting step in your loop.</p>
       </div>
       <div class="term">
         <div class="term-bar"><div class="term-dots"><i></i><i></i><i></i></div><div class="term-title">auto-stage</div></div>
@@ -520,9 +520,9 @@
     <!-- 05 -->
     <article class="entry obs">
       <div>
-        <div class="entry-meta"><span class="tag evt">PostToolUse</span><span class="tag">Write·Edit</span><span class="tag rt">Node</span></div>
+        <div class="entry-meta"><span class="tag evt">PostToolUse</span><span class="tag">Write·Edit</span><span class="tag rt">Node · ~115ms</span></div>
         <h3><span class="no">05</span>format-code</h3>
-        <p>Runs the right formatter on whatever Claude just wrote — <em>ruff</em> for Python, <em>prettier</em> for JS/TS/HTML/JSON/Markdown/YAML. The agent's output lands already clean, so diffs stay about logic, not whitespace.</p>
+        <p>Runs the right formatter on whatever Claude just wrote: <em>ruff</em> for Python, <em>prettier</em> for JS/TS/HTML/JSON/Markdown/YAML. The agent's output lands already clean, so diffs stay about logic, not whitespace.</p>
       </div>
       <div class="term">
         <div class="term-bar"><div class="term-dots"><i></i><i></i><i></i></div><div class="term-title">format-code</div></div>
@@ -538,7 +538,7 @@
     <!-- 06 -->
     <article class="entry rev obs">
       <div>
-        <div class="entry-meta"><span class="tag evt">Notification</span><span class="tag">permission · idle</span><span class="tag rt">Node · ~80ms</span></div>
+        <div class="entry-meta"><span class="tag evt">Notification</span><span class="tag">permission · idle</span><span class="tag rt">Node · webhook</span></div>
         <h3><span class="no">06</span>notify-permission</h3>
         <p>Pings a Slack channel when Claude is stuck on a permission prompt or has gone idle waiting on you. Start a long agentic run, switch tabs, and trust you'll be pulled back when it actually needs a human.</p>
       </div>
@@ -556,9 +556,9 @@
     <!-- 07 -->
     <article class="entry obs">
       <div>
-        <div class="entry-meta"><span class="tag evt">PreToolUse</span><span class="tag">Bash · Edit · Write</span><span class="tag rt">Node · ~80ms</span></div>
+        <div class="entry-meta"><span class="tag evt">PreToolUse</span><span class="tag">Bash · Edit · Write</span><span class="tag rt">Node · ~35ms</span></div>
         <h3><span class="no">07</span>protect-tests</h3>
-        <p>Stops the "fake green" ending: an agent that can't make a test pass will sometimes delete it, rename it out of discovery, or slip in a <em>.skip</em>. This hook refuses all three — while still allowing you to re-enable tests freely.</p>
+        <p>Stops the "fake green" ending: an agent that can't make a test pass will sometimes delete it, rename it out of discovery, or slip in a <em>.skip</em>. This hook refuses all three: while still allowing you to re-enable tests freely.</p>
       </div>
       <div class="term">
         <div class="term-bar"><div class="term-dots"><i></i><i></i><i></i></div><div class="term-title">protect-tests</div></div>
@@ -574,9 +574,9 @@
     <!-- 08 -->
     <article class="entry rev obs">
       <div>
-        <div class="entry-meta"><span class="tag evt">SessionStart · SessionEnd</span><span class="tag">PostToolUse · async</span><span class="tag rt">Node · ~80ms</span></div>
+        <div class="entry-meta"><span class="tag evt">SessionStart · SessionEnd</span><span class="tag">PostToolUse · async</span><span class="tag rt">Node · async</span></div>
         <h3><span class="no">08</span>session-logger</h3>
-        <p>Writes a durable markdown log of every session — repo, files touched, bash commands (secrets redacted) — without adding a millisecond to the loop. Point <em>CC_SESSION_LOG_DIR</em> at an Obsidian vault and your agent keeps a diary.</p>
+        <p>Writes a durable markdown log of every session (repo, files touched, bash commands with secrets redacted): without adding a millisecond to the loop. Point <em>CC_SESSION_LOG_DIR</em> at an Obsidian vault and your agent keeps a diary.</p>
       </div>
       <div class="term">
         <div class="term-bar"><div class="term-dots"><i></i><i></i><i></i></div><div class="term-title">session-logger</div></div>
@@ -592,9 +592,9 @@
     <!-- 09 -->
     <article class="entry obs">
       <div>
-        <div class="entry-meta"><span class="tag evt">PreToolUse</span><span class="tag">Bash</span><span class="tag rt">Node · ~80ms</span></div>
+        <div class="entry-meta"><span class="tag evt">PreToolUse</span><span class="tag">Bash</span><span class="tag rt">Node · ~35ms</span></div>
         <h3><span class="no">09</span>case-insensitive-guard</h3>
-        <p>On APFS, exFAT and NTFS, <em>Content</em> and <em>content</em> are the same path — an agent typing the wrong case deletes the real thing. Resolves every <em>rm</em>/<em>mv</em> target through <em>cd</em> chains and quotes, and blocks only provable case-collisions.</p>
+        <p>On APFS, exFAT and NTFS, <em>Content</em> and <em>content</em> are the same path: an agent typing the wrong case deletes the real thing. Resolves every <em>rm</em>/<em>mv</em> target through <em>cd</em> chains and quotes, and blocks only provable case-collisions.</p>
       </div>
       <div class="term">
         <div class="term-bar"><div class="term-dots"><i></i><i></i><i></i></div><div class="term-title">case-insensitive-guard</div></div>
@@ -602,7 +602,7 @@
           <span class="l"><span class="key">tool</span>    <span class="val">Bash</span></span>
           <span class="l"><span class="key">command</span> <span class="val">cd app && rm -rf Content</span></span>
           <span class="l verdict block"><span class="badge">⊘ blocked</span><span class="code">exit 2</span></span>
-          <span class="l verdict-note">"'content' exists — same path on this disk"</span>
+          <span class="l verdict-note">"'content' exists: same path on this disk"</span>
         </div>
       </div>
     </article>
@@ -610,7 +610,7 @@
     <!-- 10 -->
     <article class="entry rev obs">
       <div>
-        <div class="entry-meta"><span class="tag evt">PreToolUse</span><span class="tag">Bash·Edit·Write</span><span class="tag rt">Node · ~80ms</span></div>
+        <div class="entry-meta"><span class="tag evt">PreToolUse</span><span class="tag">Bash·Edit·Write</span><span class="tag rt">Node · ~35ms</span></div>
         <h3><span class="no">10</span>config-guard</h3>
         <p>Who guards the guards? Blocks the agent from rewriting its own guardrail config: <em>settings.json</em>, <em>.claude/hooks/</em>, <em>.mcp.json</em>, plugin manifests. Creating a protected file that doesn't exist yet counts as mutation (that exact gap was CVE-2026-25725). Reads always pass.</p>
       </div>
@@ -628,7 +628,7 @@
     <!-- 11 -->
     <article class="entry obs">
       <div>
-        <div class="entry-meta"><span class="tag evt">ConfigChange</span><span class="tag">settings · skills</span><span class="tag rt">Node · ~80ms</span></div>
+        <div class="entry-meta"><span class="tag evt">ConfigChange</span><span class="tag">settings · skills</span><span class="tag rt">Node</span></div>
         <h3><span class="no">11</span>config-watch</h3>
         <p>The out-of-band sibling of config-guard: fires when any config file changes mid-session, whoever changed it. By default it makes the change loudly visible; <em>CONFIG_WATCH_BLOCK=true</em> refuses it outright. Written for the era of the CHAINDROP worm, which hid its payload in <em>.claude/settings.json</em>.</p>
       </div>
@@ -646,7 +646,7 @@
     <!-- 12 -->
     <article class="entry rev obs">
       <div>
-        <div class="entry-meta"><span class="tag evt">InstructionsLoaded</span><span class="tag">UserPromptSubmit · PreToolUse</span><span class="tag rt">Node · ~80ms</span></div>
+        <div class="entry-meta"><span class="tag evt">InstructionsLoaded</span><span class="tag">UserPromptSubmit · PreToolUse</span><span class="tag rt">Node · ~35ms</span></div>
         <h3><span class="no">12</span>instructions-audit</h3>
         <p>Scans every CLAUDE.md and rules file as it loads for hidden directives: invisible-Unicode smuggling, bidi overrides, secret exfiltration, decode-and-execute, hook tampering. The event can't block by itself, so the hook locks the session instead: every prompt and tool call is refused until a human fixes the file.</p>
       </div>
@@ -662,7 +662,7 @@
     </article>
 
     <p style="font-family:var(--mono);font-size:.8rem;color:var(--faint);margin-top:2rem;padding-top:1.5rem;border-top:1px solid var(--line)">
-      + <span style="color:var(--dim)">event-logger</span> — a Python diagnostic that dumps every event's JSON so you can see an event's shape before you write a hook against it. The thing you reach for first.
+      + <span style="color:var(--dim)">event-logger</span>: a Python diagnostic that dumps every event's JSON so you can see an event's shape before you write a hook against it. The thing you reach for first.
     </p>
   </section>
 
@@ -671,8 +671,8 @@
     <div class="sec-head">
       <div>
         <div class="kicker">The marketplace</div>
-        <h2>Nineteen plugins. One command each.</h2>
-        <p style="font-family:var(--mono);font-size:.76rem;color:var(--faint);margin-top:.7rem">The <a href="#catalog" style="color:var(--pass);border-bottom:1px solid var(--pass-dim)">guardrail twelve ↑</a> plus these seven workflow plugins.</p>
+        <h2>Twenty plugins. One command each.</h2>
+        <p style="font-family:var(--mono);font-size:.76rem;color:var(--faint);margin-top:.7rem">The <a href="#catalog" style="color:var(--pass);border-bottom:1px solid var(--pass-dim)">guardrail twelve ↑</a> plus these seven workflow plugins and the six-in-one guard pack.</p>
       </div>
       <div class="aside">node · MIT<br>/plugin install</div>
     </div>
@@ -680,15 +680,15 @@
     <div class="term mkt-flow obs">
       <div class="term-bar">
         <div class="term-dots"><i></i><i></i><i></i></div>
-        <div class="term-title">~/repo — claude</div>
+        <div class="term-title">~/repo - claude</div>
       </div>
       <div class="term-body">
         <span class="l comment"># 1 · add the marketplace, once</span>
         <span class="l prompt">/plugin marketplace add karanb192/claude-code-hooks</span>
-        <span class="l comment"># 2 · install any of the nineteen by name</span>
+        <span class="l comment"># 2 · install any of the twenty by name</span>
         <span class="l prompt">/plugin install block-dangerous-commands@claude-code-hooks</span>
-        <span class="l verdict pass"><span class="badge">✓ ready</span><span class="code">19 plugins available</span></span>
-        <span class="l comment"># or from your shell — claude plugin marketplace add · claude plugin install</span>
+        <span class="l verdict pass"><span class="badge">✓ ready</span><span class="code">20 plugins available</span></span>
+        <span class="l comment"># or from your shell: claude plugin marketplace add · claude plugin install</span>
       </div>
     </div>
 
@@ -696,21 +696,21 @@
       <!-- 13 -->
       <article class="pcard obs">
         <h3><span class="no">13</span>context-hogs</h3>
-        <p>Per-file context-cost leaderboard — which files eat your tokens.</p>
+        <p>Per-file context-cost leaderboard: which files eat your tokens.</p>
         <span class="cmd">/context-hogs:leaderboard</span>
         <div class="events"><span class="tag evt">PostToolUse</span><span class="tag evt">SessionEnd</span></div>
       </article>
       <!-- 14 -->
       <article class="pcard obs">
         <h3><span class="no">14</span>nerf-receipts</h3>
-        <p>Personal model-quality flight recorder — your own receipts when Claude feels nerfed.</p>
+        <p>Personal model-quality flight recorder: your own receipts when Claude feels nerfed.</p>
         <span class="cmd">/nerf-receipts:receipts</span>
         <div class="events"><span class="tag evt">SessionStart</span><span class="tag evt">PostToolUse</span><span class="tag evt">PostToolUseFailure</span><span class="tag evt">Stop</span><span class="tag evt">SubagentStop</span><span class="tag evt">SessionEnd</span></div>
       </article>
       <!-- 15 -->
       <article class="pcard obs">
         <h3><span class="no">15</span>dead-rules-audit</h3>
-        <p>CLAUDE.md compliance scorecard — which rules Claude actually ignores.</p>
+        <p>CLAUDE.md compliance scorecard: which rules Claude actually ignores.</p>
         <span class="cmd">/dead-rules-audit:scorecard</span>
         <div class="events"><span class="tag evt">SessionStart</span><span class="tag evt">PostToolUse</span><span class="tag evt">SessionEnd</span></div>
       </article>
@@ -742,10 +742,17 @@
         <span class="cmd">/bounty-board:board</span>
         <div class="events"><span class="tag evt">SessionStart</span><span class="tag evt">PostToolUse</span><span class="tag evt">SessionEnd</span></div>
       </article>
+      <!-- 20 -->
+      <article class="pcard obs">
+        <h3><span class="no">20</span>guard-pack</h3>
+        <p>All six guards in one Node process: 38ms per tool call instead of 199ms for six separate installs.</p>
+        <span class="cmd">/plugin install guard-pack@claude-code-hooks</span>
+        <div class="events"><span class="tag evt">PreToolUse</span></div>
+      </article>
     </div>
 
     <p class="mkt-note">
-      Most recorders observe off the critical path — their <b>PostToolUse</b> and <b>Stop</b> hooks run <b>async: true</b>, so they write their receipts without adding latency to the agent loop. The exception is a hook whose output Claude reads back: <b>bounty-board</b> verifies and pays out its bounties synchronously.
+      Most recorders observe off the critical path: their <b>PostToolUse</b> and <b>Stop</b> hooks run <b>async: true</b>, so they write their receipts without adding latency to the agent loop. The exception is a hook whose output Claude reads back: <b>bounty-board</b> verifies and pays out its bounties synchronously.
     </p>
   </section>
 
@@ -823,23 +830,23 @@
       <div class="spec obs">
         <div class="lbl">Safety</div>
         <h4>Three levels of paranoia</h4>
-        <div class="row"><b>critical</b><span class="d">catastrophes only — rm -rf ~, fork bombs, dd</span><span></span></div>
-        <div class="row rec"><b>high</b><span class="d">+ risky — force push, secrets, hard reset</span><span class="star">★ default</span></div>
-        <div class="row"><b>strict</b><span class="d">+ cautionary — any force push, sudo rm</span><span></span></div>
+        <div class="row"><b>critical</b><span class="d">catastrophes only: rm -rf ~, fork bombs, dd</span><span></span></div>
+        <div class="row rec"><b>high</b><span class="d">+ risky: force push, secrets, hard reset</span><span class="star">★ default</span></div>
+        <div class="row"><b>strict</b><span class="d">+ cautionary: any force push, sudo rm</span><span></span></div>
       </div>
       <div class="spec obs">
         <div class="lbl">Runtime</div>
         <h4>Match language to event rate</h4>
-        <div class="row"><b>Bash</b><span class="d">tiny guards</span><span class="n">10–20ms</span></div>
-        <div class="row"><b>Node</b><span class="d">per-tool, JSON-heavy</span><span class="n">50–100ms</span></div>
-        <div class="row"><b>Python</b><span class="d">session events</span><span class="n">200–400ms</span></div>
+        <div class="row"><b>Bash</b><span class="d">tiny guards</span><span class="n">10-20ms</span></div>
+        <div class="row"><b>Node</b><span class="d">per-tool, JSON-heavy</span><span class="n">35-115ms</span></div>
+        <div class="row"><b>Python</b><span class="d">session events</span><span class="n">200-400ms</span></div>
       </div>
       <div class="spec obs">
         <div class="lbl">Exits</div>
         <h4>Two numbers do the work</h4>
-        <div class="row exit-row"><b class="zero">0</b><span class="d">pass — let the tool run</span><span></span></div>
-        <div class="row exit-row"><b class="two">2</b><span class="d">block — message goes back to Claude</span><span></span></div>
-        <div class="row exit-row"><b>·</b><span class="d">other — non-blocking warning, logged</span><span></span></div>
+        <div class="row exit-row"><b class="zero">0</b><span class="d">pass: let the tool run</span><span></span></div>
+        <div class="row exit-row"><b class="two">2</b><span class="d">block: message goes back to Claude</span><span></span></div>
+        <div class="row exit-row"><b>·</b><span class="d">other: non-blocking warning, logged</span><span></span></div>
       </div>
     </div>
   </section>
@@ -866,7 +873,7 @@
   <!-- ═══════ CLOSING ═══════ -->
   <section class="close">
     <h2>Put a hook in the loop.</h2>
-    <p>Nineteen tested plugins: twelve guardrails plus seven workflow tools, MIT licensed, no framework to learn. Install one and restart Claude Code, and you're protected in under a minute.</p>
+    <p>Twenty tested plugins: twelve guardrails, seven workflow tools, and a six-in-one guard pack, MIT licensed, no framework to learn. Install one and restart Claude Code, and you're protected in under a minute.</p>
     <div class="cta-row">
       <a class="btn btn-primary" href="https://github.com/karanb192/claude-code-hooks">
         <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.5 2 2 6.6 2 12.2c0 4.5 2.9 8.3 6.8 9.7.5.1.7-.2.7-.5v-1.7c-2.8.6-3.4-1.4-3.4-1.4-.5-1.2-1.1-1.5-1.1-1.5-.9-.6.1-.6.1-.6 1 .1 1.5 1 1.5 1 .9 1.6 2.4 1.1 3 .9.1-.7.4-1.1.6-1.4-2.2-.3-4.6-1.1-4.6-5 0-1.1.4-2 1-2.7-.1-.3-.4-1.3.1-2.7 0 0 .8-.3 2.7 1a9.3 9.3 0 0 1 5 0c1.9-1.3 2.7-1 2.7-1 .5 1.4.2 2.4.1 2.7.6.7 1 1.6 1 2.7 0 3.9-2.4 4.7-4.6 5 .4.3.7.9.7 1.9v2.8c0 .3.2.6.7.5 3.9-1.4 6.8-5.2 6.8-9.7C22 6.6 17.5 2 12 2Z"/></svg>
@@ -887,7 +894,7 @@
 </footer>
 
 <script>
-  // copy buttons — grab the sibling <pre>, strip shell prompts
+  // copy buttons - grab the sibling <pre>, strip shell prompts
   document.querySelectorAll('.copy').forEach(btn => {
     btn.addEventListener('click', async () => {
       const pre = btn.parentNode.querySelector('pre');


### PR DESCRIPTION
## What

An audit of README + landing page on main found the README already solid (counts, badge, links all check out post #43/#44/#45) but the GitHub Pages catalog stale on three fronts:

1. **guard-pack was missing entirely** (shipped in #45; the site was last touched in #43). It now has card 20 in the marketplace grid with the measured tagline: 38ms per tool call instead of 199ms for six separate installs.
2. **Counts and receipts drifted**: hero tiles said 19 plugins / 1544 tests / ~80ms per call; the marketplace headline, its subline, the meta description, and the closing pitch all said nineteen. Everything now says 20 plugins / 1570 tests, and the closing line describes the real composition (twelve guardrails, seven workflow tools, one guard pack).
3. **Latency claims contradicted the committed bench**: ten hook cards claimed ~80ms while bench/RESULTS.md measures ~35ms medians for the guards. Measured cards now carry their bench numbers (~35ms guards and the instructions-audit arm, ~65ms auto-stage, ~115ms format-code); unmeasured ones drop the fake number for honest labels (session-logger "async", notify-permission "webhook"). The hook-author cost table's Node row moved from 50-100ms to the measured 35-115ms spread.

Also clears the page's 32 em and en dashes (decorative terminal chrome, step labels, prose), the last file in the repo carrying any: the repo is now fully dash-free.

## Verification

Served locally and eyeballed rendered screenshots at hero, catalog, and marketplace scroll depths: guard-pack card renders, stats tiles show 20/1570/~35ms, scroll-reveal animations intact, no console errors beyond the favicon 404 the server always had.