### PR TITLE
fix(protect-secrets): close the grep and Grep-tool .env bypasses

### DIFF
--- a/plugins/guard-pack/lib/protect-secrets.js
+++ b/plugins/guard-pack/lib/protect-secrets.js
@@ -103,6 +103,7 @@ const SENSITIVE_FILES = [
 // Bash patterns that expose or exfiltrate secrets
 const BASH_PATTERNS = [
   // CRITICAL
+  { level: 'critical', id: 'grep-env',           regex: /\b(grep|rg|egrep|fgrep|ag|awk|gawk)\b(?:"[^"]*"|'[^']*'|[^|;&])*\.env\b/i, reason: 'Reading .env via text tools exposes secrets' },
   { level: 'critical', id: 'cat-env',            regex: /\b(cat|less|head|tail|more|bat|view)\s+[^|;]*\.env\b/i,           reason: 'Reading .env file exposes secrets' },
   { level: 'critical', id: 'cat-ssh-key',        regex: /\b(cat|less|head|tail|more|bat)\s+[^|;]*(id_rsa|id_ed25519|id_ecdsa|id_dsa|\.pem|\.key)\b/i, reason: 'Reading private key' },
   { level: 'critical', id: 'cat-aws-creds',      regex: /\b(cat|less|head|tail|more)\s+[^|;]*\.aws\/credentials/i,         reason: 'Reading AWS credentials' },
@@ -185,6 +186,12 @@ function checkBashCommand(cmd, safetyLevel = SAFETY_LEVEL) {
 }
 
 function check(toolName, toolInput, safetyLevel = SAFETY_LEVEL) {
+  if (toolName === 'Grep') {
+    const candidates = [toolInput.path, toolInput.glob, toolInput.include].filter(Boolean);
+    const target = candidates.find(c => SENSITIVE_FILES.some(s => s.regex.test(c))) || candidates[0] || '';
+    toolInput = { file_path: target };
+    toolName = 'Read';
+  }
   if (['Read', 'Edit', 'Write'].includes(toolName)) {
     return checkFilePath(toolInput?.file_path, safetyLevel);
   }
@@ -202,7 +209,7 @@ async function main() {
     const data = JSON.parse(input);
     const { tool_name, tool_input, session_id, cwd, permission_mode } = data;
 
-    if (!['Read', 'Edit', 'Write', 'Bash'].includes(tool_name)) {
+    if (!['Read', 'Edit', 'Write', 'Bash', 'Grep'].includes(tool_name)) {
       return console.log('{}');
     }
 
@@ -215,7 +222,7 @@ async function main() {
       const target = tool_input?.file_path || tool_input?.command?.slice(0, 100);
       log({ level: shouldAsk ? 'ASK' : 'BLOCKED', id: p.id, priority: p.level, decision, tool: tool_name, target, session_id, cwd, permission_mode });
 
-      const action = { Read: 'read', Edit: 'modify', Write: 'write to', Bash: 'execute' }[tool_name];
+      const action = { Read: 'read', Edit: 'modify', Write: 'write to', Bash: 'execute', Grep: 'search' }[tool_name];
       return console.log(JSON.stringify({
         hookSpecificOutput: {
           hookEventName: 'PreToolUse',

--- a/plugins/protect-secrets/protect-secrets.js
+++ b/plugins/protect-secrets/protect-secrets.js
@@ -103,6 +103,7 @@ const SENSITIVE_FILES = [
 // Bash patterns that expose or exfiltrate secrets
 const BASH_PATTERNS = [
   // CRITICAL
+  { level: 'critical', id: 'grep-env',           regex: /\b(grep|rg|egrep|fgrep|ag|awk|gawk)\b(?:"[^"]*"|'[^']*'|[^|;&])*\.env\b/i, reason: 'Reading .env via text tools exposes secrets' },
   { level: 'critical', id: 'cat-env',            regex: /\b(cat|less|head|tail|more|bat|view)\s+[^|;]*\.env\b/i,           reason: 'Reading .env file exposes secrets' },
   { level: 'critical', id: 'cat-ssh-key',        regex: /\b(cat|less|head|tail|more|bat)\s+[^|;]*(id_rsa|id_ed25519|id_ecdsa|id_dsa|\.pem|\.key)\b/i, reason: 'Reading private key' },
   { level: 'critical', id: 'cat-aws-creds',      regex: /\b(cat|less|head|tail|more)\s+[^|;]*\.aws\/credentials/i,         reason: 'Reading AWS credentials' },
@@ -185,6 +186,12 @@ function checkBashCommand(cmd, safetyLevel = SAFETY_LEVEL) {
 }
 
 function check(toolName, toolInput, safetyLevel = SAFETY_LEVEL) {
+  if (toolName === 'Grep') {
+    const candidates = [toolInput.path, toolInput.glob, toolInput.include].filter(Boolean);
+    const target = candidates.find(c => SENSITIVE_FILES.some(s => s.regex.test(c))) || candidates[0] || '';
+    toolInput = { file_path: target };
+    toolName = 'Read';
+  }
   if (['Read', 'Edit', 'Write'].includes(toolName)) {
     return checkFilePath(toolInput?.file_path, safetyLevel);
   }
@@ -202,7 +209,7 @@ async function main() {
     const data = JSON.parse(input);
     const { tool_name, tool_input, session_id, cwd, permission_mode } = data;
 
-    if (!['Read', 'Edit', 'Write', 'Bash'].includes(tool_name)) {
+    if (!['Read', 'Edit', 'Write', 'Bash', 'Grep'].includes(tool_name)) {
       return console.log('{}');
     }
 
@@ -215,7 +222,7 @@ async function main() {
       const target = tool_input?.file_path || tool_input?.command?.slice(0, 100);
       log({ level: shouldAsk ? 'ASK' : 'BLOCKED', id: p.id, priority: p.level, decision, tool: tool_name, target, session_id, cwd, permission_mode });
 
-      const action = { Read: 'read', Edit: 'modify', Write: 'write to', Bash: 'execute' }[tool_name];
+      const action = { Read: 'read', Edit: 'modify', Write: 'write to', Bash: 'execute', Grep: 'search' }[tool_name];
       return console.log(JSON.stringify({
         hookSpecificOutput: {
           hookEventName: 'PreToolUse',

--- a/plugins/protect-secrets/tests/protect-secrets.test.js
+++ b/plugins/protect-secrets/tests/protect-secrets.test.js
@@ -549,3 +549,55 @@ describe('Integration: HOOK_SAFETY_LEVEL override', () => {
     assert.strictEqual(output.hookSpecificOutput?.permissionDecision, 'deny');
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Bypasses found on camera during the CodeSecCon 2026 demo takes: bash grep
+// read .env straight past the cat-only patterns, and the built-in Grep tool
+// was not registered at all. Both stay covered here.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('grep-env bash pattern (demo-take bypass 1)', () => {
+  it('blocks grep on .env', () => bashBlocked('grep -E "STRIPE_API_VERSION|STRIPE_SECRET_KEY" /app/.env', 'grep-env'));
+  it('blocks rg on .env', () => bashBlocked('rg SECRET_KEY .env', 'grep-env'));
+  it('blocks awk on .env', () => bashBlocked("awk '/KEY/' .env", 'grep-env'));
+  it('blocks fgrep on a nested .env', () => bashBlocked('fgrep KEY services/billing/.env', 'grep-env'));
+  it('allows grep on source files', () => bashAllowed('grep -rn TODO src/'));
+  it('allows grep on .env.example', () => bashAllowed('grep STRIPE .env.example'));
+  it('allows grep for the word env in code', () => bashAllowed('grep -n environment src/config.js'));
+});
+
+describe('Grep tool coverage (demo-take bypass 2)', () => {
+  it('blocks Grep with path at .env', () => {
+    const result = check('Grep', { pattern: 'STRIPE', path: '/app/.env' });
+    assert.strictEqual(result.blocked, true);
+    assert.strictEqual(result.pattern.id, 'env-file');
+  });
+  it('blocks Grep with a .env glob', () => {
+    const result = check('Grep', { pattern: 'KEY', glob: '**/.env' });
+    assert.strictEqual(result.blocked, true);
+  });
+  it('blocks Grep with include targeting .env', () => {
+    const result = check('Grep', { pattern: 'KEY', include: '.env' });
+    assert.strictEqual(result.blocked, true);
+  });
+  it('allows Grep on normal paths', () => {
+    const result = check('Grep', { pattern: 'TODO', path: 'src/' });
+    assert.strictEqual(result.blocked, false);
+  });
+  it('allows Grep on .env.example', () => {
+    const result = check('Grep', { pattern: 'STRIPE', path: '.env.example' });
+    assert.strictEqual(result.blocked, false);
+  });
+  // Documented residual: a pattern-only Grep with no path/glob searches the
+  // whole tree and can still surface secret lines. Blocking it would break
+  // normal use; the sensible mitigation is output-side, not pattern matching.
+  it('allows pattern-only Grep (documented residual)', () => {
+    const result = check('Grep', { pattern: 'TODO' });
+    assert.strictEqual(result.blocked, false);
+  });
+  it('end to end: Grep on .env denies with a search message', async () => {
+    const { output } = await runHook('Grep', { pattern: 'STRIPE', path: '/app/.env' });
+    assert.strictEqual(output.hookSpecificOutput?.permissionDecision, 'deny');
+    assert.match(output.hookSpecificOutput?.permissionDecisionReason || '', /search/i);
+  });
+});


### PR DESCRIPTION
Fixes #47.

Two ways an agent read `.env` past `protect-secrets`, both surfaced while recording demos for the CodeSecCon talk. The failed takes are the proof of concept; this is the fix plus regression tests.

## What was wrong
1. **Bash text-search tools.** `cat-env` only covered `cat/less/head/tail/more/bat/view`. `grep -E "STRIPE_API_VERSION|STRIPE_SECRET_KEY" .env` read the file cleanly. A pipe inside the quoted pattern also defeats a plain `[^|;&]*` separator guard.
2. **The built-in `Grep` tool.** Not registered at all, so `Grep(pattern=..., path=".env")` was never inspected.

## The fix
- New `grep-env` critical Bash pattern for `grep/rg/egrep/fgrep/ag/awk/gawk` targeting `.env`. The middle of the pattern skips over single- and double-quoted strings, so a `|` inside quotes no longer breaks the separator guard while a real shell separator still stops the match (a following `cat .env` is left to `cat-env`).
- `Grep` added to the accepted tool list and normalized to a `Read` against its `path`/`glob`/`include` target, so it flows through the existing `checkFilePath` logic and denies with a search-flavored message.

## Scope kept tight
- `.env.example` and ordinary source-tree greps stay allowed (existing allowlist covers them; tests assert it).
- One documented residual: a pattern-only `Grep` with no path searches the whole tree and can still surface a secret line. Blocking that would break normal search; the honest mitigation is output-side, not pattern matching. Called out in a test and a comment rather than papered over.

## Tests
14 new regression tests (both bypass groups, the on-camera command shapes, the quoted-pipe variant, and the documented residual). Full suite **1584 pass / 0 fail**. guard-pack `lib/` copy kept byte-identical (drift test passes).