### PR TITLE
test(guard-pack): isolate the env-passthrough test from the runner's git branch

### DIFF
--- a/plugins/guard-pack/tests/guard-pack.test.js
+++ b/plugins/guard-pack/tests/guard-pack.test.js
@@ -31,7 +31,10 @@ function runHook(payload, envOverrides = {}) {
         delete env[key];
       }
     }
-    const child = spawn('node', [SCRIPT_PATH], { env });
+    // cwd is the isolated TMP_HOME (not a git repo) so branchOnly guards like
+    // git-safety's push-on-protected read '' for the branch instead of leaking
+    // in whatever branch CI happens to be on (push-to-main runs were HEAD=main).
+    const child = spawn('node', [SCRIPT_PATH], { env, cwd: TMP_HOME });
     let stdout = '';
     let stderr = '';
     child.stdout.on('data', (d) => { stdout += d; });


### PR DESCRIPTION
## The symptom
`Tests on main (push)` has been red on every push to main (e.g. the run after #48 merged, and identically on Aug 18 before it). The PR checks were always green, so it only ever showed up after merge.

## Root cause
One test fails: `guard-pack.test.js` -> `Integration: env passthrough` -> "HOOK_SAFETY_LEVEL=strict tightens every guard in the pack". It runs `git push --force origin feature-branch` and asserts default mode returns `{}` (a force-push to a *feature* branch is only a strict-tier concern).

The actual output on main-push runs is a deny: `[push-on-protected] Pushing from main is not allowed`. That is git-safety's `push-on-protected` guard, which is `branchOnly` and resolves the branch with `git branch --show-current` in **`process.cwd()`**. `runHook` spawned the hook child without a `cwd`, so it inherited the runner's working directory:

- **push to main**: HEAD is `main` -> guard fires -> test sees a deny instead of `{}` -> red.
- **pull_request**: GitHub checks out a detached merge ref -> branch is not `main` -> guard stays quiet -> `{}` -> green.

So the test was coupled to whatever branch CI happened to be sitting on. Reproduced locally by running the suite with HEAD on `main`.

## The fix
Spawn the hook child in the already-isolated `TMP_HOME` (created with `mkdtemp`, not a git repo). `getCurrentBranch()` then returns `''`, so `branchOnly` guards behave deterministically regardless of the runner's branch. This also makes the child's cwd match the `cwd` the payload already advertises.

Test-only change. git-safety's production behavior is unchanged: in real use the hook process runs from the project directory, so reading the branch from `process.cwd()` is correct.

## Verified
Full suite **1584 pass / 0 fail with HEAD on `main`**, the exact condition that was failing. The other test files that spawn the hook were checked and pass on main (their branch-dependent assertions pass an explicit branch to `checkCommand`).