### PR TITLE
cache-tax 1.0.1: ignore synthetic assistant entries when reading the last turn

### DIFF
--- a/plugins/cache-tax/.claude-plugin/plugin.json
+++ b/plugins/cache-tax/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cache-tax",
   "description": "The comeback price of a cold prompt cache, shown before you pay it. A UserPromptSubmit guard warns (or refuses once) when your next message will re-write a lapsed 1-hour cache at up to 80x the read rate, a SessionStart hook prices a stale resume, and the same script is a one-line status line segment with the minutes left and the cold-comeback cost.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "Karan Bansal",
     "url": "https://github.com/karanb192"

--- a/plugins/cache-tax/README.md
+++ b/plugins/cache-tax/README.md
@@ -33,7 +33,7 @@ cache-tax: the 1h prompt cache lapsed 3h00m ago. This message re-writes 300,002 
 
 ## What Claude Code already does, and where this adds
 
-On `--resume` of a session older than its cache TTL, recent Claude Code versions (since 2.1.208) show their own dialog, "this session is N old and M tokens, we recommend resuming from a summary". That covers the resume path in tokens. cache-tax adds the dollar figure there, and covers the case that dialog cannot see: a session you left open, came back to after an hour, and typed into. Nothing native intervenes at that keystroke.
+On `--resume` of a session older than its cache TTL, recent Claude Code versions (seen on 2.1.261) show their own dialog, "this session is N old and M tokens, we recommend resuming from a summary". That covers the resume path in tokens. cache-tax adds the dollar figure there, and covers the case that dialog cannot see: a session you left open, came back to after an hour, and typed into. Nothing native intervenes at that keystroke.
 
 ## Status line segment
 

--- a/plugins/cache-tax/README.md
+++ b/plugins/cache-tax/README.md
@@ -31,6 +31,10 @@ cache-tax: the 1h prompt cache lapsed 3h00m ago. This message re-writes 300,002 
 (a warm turn would have cost $0.08). If most of that context is stale, /clear and start from a handoff note instead.
 ```
 
+## What Claude Code already does, and where this adds
+
+On `--resume` of a session older than its cache TTL, recent Claude Code versions (since 2.1.208) show their own dialog, "this session is N old and M tokens, we recommend resuming from a summary". That covers the resume path in tokens. cache-tax adds the dollar figure there, and covers the case that dialog cannot see: a session you left open, came back to after an hour, and typed into. Nothing native intervenes at that keystroke.
+
 ## Status line segment
 
 Plugins cannot ship a status line, so wire this one yourself. The same script prints one line when called with `--statusline`, and it prefers the native `prompt_cache` object Claude Code sends to status lines since v2.1.251 (`expires_at`, `recache_tokens_if_cold`, `ttl`, `last_miss_cause`), which also means Claude Code re-runs it the moment the cache goes cold.

--- a/plugins/cache-tax/cache-tax.js
+++ b/plugins/cache-tax/cache-tax.js
@@ -88,12 +88,17 @@ function parseUsageLine(line) {
   if (!u) return null;
   const ts = Date.parse(o.timestamp || '');
   if (!Number.isFinite(ts)) return null;
+  // Claude Code also writes local, synthetic assistant entries (orphaned-task
+  // notices, aborted turns) with model "<synthetic>" and all-zero usage. They
+  // carry a fresh timestamp and no context, so they must not count as a turn.
+  if (String(msg.model || '').startsWith('<')) return null;
   const cc = u.cache_creation || {};
   const write = Number(u.cache_creation_input_tokens) || 0;
   const w5 = Number(cc.ephemeral_5m_input_tokens) || 0;
   const w1 = Number(cc.ephemeral_1h_input_tokens) || 0;
   const read = Number(u.cache_read_input_tokens) || 0;
   const input = Number(u.input_tokens) || 0;
+  if (write + read + input === 0) return null;
   return {
     ts, model: msg.model || null, requestId: o.requestId || msg.id || null,
     write, w5, w1,

--- a/plugins/cache-tax/tests/cache-tax.test.js
+++ b/plugins/cache-tax/tests/cache-tax.test.js
@@ -70,6 +70,14 @@ describe('transcript parsing', () => {
     assert.strictEqual(parseUsageLine('{"type":"user","message":{"usage":{}}}'), null);
     assert.strictEqual(parseUsageLine('not json "assistant" "usage"'), null);
   });
+  it('skips synthetic and zero-usage assistant entries', () => {
+    const synthetic = JSON.stringify({ type: 'assistant', timestamp: new Date(3000).toISOString(), message: { model: '<synthetic>', id: 'syn', usage: { input_tokens: 0, cache_creation_input_tokens: 0, cache_read_input_tokens: 0, output_tokens: 0 } } });
+    assert.strictEqual(parseUsageLine(synthetic), null);
+    const p = writeTranscript(tmp, [{ ts: 1000, write: 10, read: 90000 }, synthetic]);
+    const u = readLastUsage(p);
+    assert.strictEqual(u.ts, 1000, 'the real turn, not the synthetic one after it');
+    assert.strictEqual(u.ctx, 90012);
+  });
   it('readLastUsage returns the newest block', () => {
     const p = writeTranscript(tmp, [{ ts: 1000, write: 10, read: 0 }, { ts: 2000, write: 5, read: 50 }]);
     const u = readLastUsage(p);


### PR DESCRIPTION
## Summary
- `parseUsageLine` now returns null for assistant entries whose model starts with `<` (Claude Code's `<synthetic>` local entries) or whose input, cache-read and cache-write tokens are all zero
- New test: a synthetic entry after a real turn is skipped and the real turn decides state
- Plugin version 1.0.0 to 1.0.1

## Details
Found while testing the merged 1.0.0 on a real resume. Claude Code appends local assistant entries (model `<synthetic>`, usage all zeros, current timestamp) for things like the orphaned-background-task notice. `readLastUsage` took one as the newest turn, so a session whose last real turn was 2 days and 300k tokens ago rendered as `cache 58m left · 0 · cold costs n/a` and the guard stayed silent. With the fix the same transcript renders `cache LAPSED 2d 3h ago · next msg re-writes 300k = $6.00` and the guard fires. The SessionStart resume path was unaffected because it uses Claude Code's own fields.

## Test plan
- [x] `node --test plugins/cache-tax/tests/cache-tax.test.js` 26/26
- [x] `npm test` 1610/1610
- [x] The real transcript that exposed the bug now reports LAPSED with the correct tokens and dollars through both `--statusline` and the guard

Generated with Claude Code